### PR TITLE
Set CheckoutUtility URL

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -44,6 +44,8 @@ module Adyen
         case service
         when "Checkout"
           url = "https://checkout-#{@env}.adyen.com/checkout/services/PaymentSetupAndVerification"
+        when "CheckoutUtility"
+          url = "https://checkout-#{@env}.adyen.com"
         when "Account", "Fund", "Notification"
           url = "https://cal-#{@env}.adyen.com/cal/services"
         when "Recurring", "Payment", "Payout"

--- a/spec/checkout_utility_spec.rb
+++ b/spec/checkout_utility_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe Adyen::CheckoutUtility, service: "checkout utility" do
     }
   end
 
+  it "sets the correct service URL base" do
+    client = Adyen::Client.new(env: :test)
+    expect(client.service_url_base(@shared_values[:service])).to eq("https://checkout-test.adyen.com")
+  end
+
   # must be created manually because every field in the response is an array
   it "makes an origin_keys call" do
     parsed_body = create_test(@shared_values[:client], @shared_values[:service], "origin_keys", @shared_values[:client].checkout_utility)


### PR DESCRIPTION
The client.rb class was missing a case to set the base service URL of the CheckoutUtility.


To test, from the root directory - 
```
irb
require_relative "lib/adyen"
client = Adyen::Client.new(env: :test, api_key: "XXX")
client.checkout_utility.origin_keys(originDomains: ["http://127.0.0.1"])
```

**master**
`=> ArgumentError: Invalid service specified`

**checkout-utility-url**
`=> "{\"originKeys\":{\"http:\\/\\/127.0.0.1\":\"pub.v2.XXX\"}}"`