### PR TITLE
Fix JSON syntax error in payouts example

### DIFF
--- a/docs/payout.html
+++ b/docs/payout.html
@@ -88,7 +88,7 @@ adyen.ws_passord = "super_secure_password123"</code></pre></p>
     "shopperReference" : "&lt;ShopperReference&gt;",
     "dateOfBirth" : "1990-01-01",
     "entityType" : "Company",
-    "nationality" : "NL",
+    "nationality" : "NL"
 }')</code></pre>
 
         <h3 id="submitapayout">Submit a payout</h3>


### PR DESCRIPTION
Remove illegal trailing comma in dictionary.