### PR TITLE
Add missing attr_reader for msg in AdyenError

### DIFF
--- a/lib/adyen/errors.rb
+++ b/lib/adyen/errors.rb
@@ -1,6 +1,6 @@
 module Adyen
   class AdyenError < StandardError
-    attr_reader :code, :response, :request
+    attr_reader :code, :response, :request, :msg
 
     def initialize(request = nil, response = nil, msg = nil, code = nil)
       @code = code


### PR DESCRIPTION
`@msg` is important because for, eg, PermissionError, it's the only way to see the details about what the error is:

```ruby
[21] pry(main)> e
=> #<Adyen::PermissionError: Adyen::PermissionError>
[22] pry(main)> e.code
=> 403
[23] pry(main)> e.response
=> nil
[24] pry(main)> e.msg
NoMethodError: undefined method `msg' for #<Adyen::PermissionError: Adyen::PermissionError>
from (pry):24:in `rescue in <main>'
[25] pry(main)> e.instance_variable_get('@msg')
=> "Invalid Checkout API key"
```