### PR TITLE
Add attributes to Error message

### DIFF
--- a/lib/adyen/errors.rb
+++ b/lib/adyen/errors.rb
@@ -3,6 +3,14 @@ module Adyen
     attr_reader :code, :response, :request, :msg
 
     def initialize(request = nil, response = nil, msg = nil, code = nil)
+      attributes = {
+        code: code,
+        request: request,
+        response: response,
+        msg: msg
+      }.select { |_k, v| v }.map { |k, v| "#{k}:#{v}" }.join(', ')
+      message = "#{self.class.name} #{attributes}"
+      super(message)
       @code = code
       @response = response
       @request = request
@@ -12,65 +20,44 @@ module Adyen
 
   class AuthenticationError < AdyenError
     def initialize(msg, request)
-      @code = 401
-      @response = nil
-      @request = request
-      @msg = msg
+      super(request, nil, msg, 401)
     end
   end
 
   class PermissionError < AdyenError
     def initialize(msg, request)
-      @code = 403
-      @response = nil
-      @request = request
-      @msg = msg
+      super(request, nil, msg, 403)
     end
   end
 
   class FormatError < AdyenError
     def initialize(msg, request, response)
-      @code = 422
-      @response = response
-      @request = request
-      @msg = msg
+      super(request, response, msg, 422)
     end
   end
 
   class ServerError < AdyenError
     def initialize(msg, request, response)
-      @code = 500
-      @response = response
-      @request = request
-      @msg = msg
+      super(request, response, msg, 500)
     end
   end
 
   class ConfigurationError < AdyenError
     def initialize(msg, request)
-      @code = 905
-      @response = nil
-      @request = request
-      @msg = msg
+      super(request, nil, msg, 905)
     end
   end
 
   class ValidationError < AdyenError
     def initialize(msg, request)
-      @code = nil
-      @response = nil
-      @request = request
-      @msg = msg
+      super(request, nil, msg, nil)
     end
   end
 
   # catchall for errors which don't have more specific classes
   class APIError < AdyenError
     def initialize(msg, request, response, code)
-      @code = code
-      @response = response
-      @request = request
-      @msg = msg
+      super(request, response, msg, code)
     end
   end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Adyen::AdyenError do
+  describe '#to_s' do
+    it 'describes using the error properties' do
+      expect(Adyen::AdyenError.new('request', 'response', 'message', 'code').to_s).to eq('Adyen::AdyenError code:code, request:request, response:response, msg:message')
+    end
+    it 'skips the null properties' do
+      expect(Adyen::AdyenError.new('request', nil, nil, 'code').to_s).to eq('Adyen::AdyenError code:code, request:request')
+    end
+    it 'uses the proper error class name' do
+      expect(Adyen::PermissionError.new('a message', 'a request').to_s).to eq('Adyen::PermissionError code:403, request:a request, msg:a message')
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the `AdyenError` attributes information in the error message.
This will helps during debugging as the attributes would show more easily.
