### PR TITLE
The service should be Checkout instead of CheckoutUtility.

### DIFF
--- a/lib/adyen/services/checkout_utility.rb
+++ b/lib/adyen/services/checkout_utility.rb
@@ -5,7 +5,7 @@ module Adyen
     DEFAULT_VERSION = 1
 
     def initialize(client, version = DEFAULT_VERSION)
-      service = 'CheckoutUtility'
+      service = 'Checkout'
       method_names = [
         :origin_keys
       ]


### PR DESCRIPTION
The endpoint on LIVE does not work with CheckoutUtility. The LIVE endpoint for originKeys (or all checkout endpoints) should be:
`https://{{prefix}}-checkout-live.adyenpayments.com/checkout/v50/originKeys