### PR TITLE
add optional headers param to service methods

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -69,7 +69,7 @@ module Adyen
     end
 
     # send request to adyen API
-    def call_adyen_api(service, action, request_data, version)
+    def call_adyen_api(service, action, request_data, headers, version)
       # get URL for requested endpoint
       url = service_url(service, action, version)
 
@@ -100,7 +100,14 @@ module Adyen
         when "api-key"
           faraday.headers["x-api-key"] = @api_key
         end
+
+        # add optional headers if specified in request
+        # will overwrite default headers if overlapping
+        headers.map do |key, value|
+          faraday.headers[key] = value
+        end
       end
+
 
       # if json string convert to hash
       # needed to add applicationInfo

--- a/lib/adyen/services/checkout.rb
+++ b/lib/adyen/services/checkout.rb
@@ -23,9 +23,10 @@ module Adyen
       case args.size
       when 0
         Adyen::CheckoutDetail.new(@client, @version)
-      when 1
+      else
         action = 'payments'
-        @client.call_adyen_api(@service, action, args[0], @version)
+        args[1] ||= {}  # optional headers arg
+        @client.call_adyen_api(@service, action, args[0], args[1], @version)
       end
     end
   end
@@ -37,14 +38,14 @@ module Adyen
       @version = version
     end
 
-    def details(request)
+    def details(request, headers = {})
       action = "payments/details"
-      @client.call_adyen_api(@service, action, request, @version)
+      @client.call_adyen_api(@service, action, request, headers, @version)
     end
 
-    def result(request)
+    def result(request, headers = {})
       action = "payments/result"
-      @client.call_adyen_api(@service, action, request, @version)
+      @client.call_adyen_api(@service, action, request, headers, @version)
     end
   end
 end

--- a/lib/adyen/services/service.rb
+++ b/lib/adyen/services/service.rb
@@ -9,9 +9,9 @@ module Adyen
 
       # dynamically create API methods
       method_names.each do |method_name|
-        define_singleton_method method_name do |request|
+        define_singleton_method method_name do |request, headers = {}|
           action = method_name.to_s.to_camel_case
-          @client.call_adyen_api(@service, action, request, @version)
+          @client.call_adyen_api(@service, action, request, headers, @version)
         end
       end
     end


### PR DESCRIPTION
Requested in https://github.com/Adyen/adyen-ruby-api-library/issues/35

Add ability to pass a generic headers hash when making API calls.