### PR TITLE
Support a custom endpoint for mock environment

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -7,13 +7,13 @@ module Adyen
     attr_accessor :ws_user, :ws_password, :api_key, :client, :adapter, :live_url_prefix
     attr_reader :env
 
-    def initialize(ws_user: nil, ws_password: nil, api_key: nil, env: :live, adapter: nil, mock_port: 3001, live_url_prefix: nil)
+    def initialize(ws_user: nil, ws_password: nil, api_key: nil, env: :live, adapter: nil, mock_port: 3001, live_url_prefix: nil, mock_service_url_base: nil)
       @ws_user = ws_user
       @ws_password = ws_password
       @api_key = api_key
       @env = env
       @adapter = adapter || Faraday.default_adapter
-      @mock_port = mock_port
+      @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       @live_url_prefix = live_url_prefix
     end
 
@@ -35,7 +35,7 @@ module Adyen
     def service_url_base(service)
       raise ArgumentError, "Please set Client.live_url_prefix to the portion of your merchant-specific URL prior to '-[service]-live.adyenpayments.com'" if @live_url_prefix.nil? and @env == :live
       if @env == :mock
-        "http://localhost:#{@mock_port}"
+        @mock_service_url_base
       else
         case service
         when "Checkout"

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe Adyen do
     @shared_values[:client].api_key = "api_key"
   end
 
+  it "uses the specified mock service URL" do
+    client = Adyen::Client.new(env: :mock, mock_service_url_base: "https://mock.test")
+    expect(client.service_url_base("Account")).
+      to eq("https://mock.test")
+  end
+
+  it "generates localhost service URL when a mock port is specified" do
+    client = Adyen::Client.new(env: :mock, mock_port: 3005)
+    expect(client.service_url_base("Account")).
+      to eq("http://localhost:3005")
+  end
+
+  it "prefers the mock service URL when both mock service URL and port are specified" do
+    client = Adyen::Client.new(env: :mock, mock_port: 3005, mock_service_url_base: "https://this-url-wins.test")
+    expect(client.service_url_base("Account")).
+      to eq("https://this-url-wins.test")
+  end
+
   it "generates the correct service URL base for CAL TEST" do
     client = Adyen::Client.new(env: :test)
     client.live_url_prefix = "abcdef1234567890-TestCompany"


### PR DESCRIPTION
This is a small improvement to let a custom base URL be set when
the `Adyen::Client` is used in the `:mock` environment, which helps
when a different hostname or scheme is desired.

To help with compatibility, if both `mock_port` and `mock_service_url_base`
are specified, then the latter wins.

See also: Adyen/adyen-ruby-api-library#41