### PR TITLE
Added checkout.payment_links call, adding Pay by Link functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ adyen.checkout.version = 50
 - payment_methods
 - payments
 - payments.details
+- payment_links
 
 **checkout utility:**
 - origin_keys

--- a/docs/checkout.html
+++ b/docs/checkout.html
@@ -41,6 +41,8 @@
         <li>payments</li>
 
         <li>payments.details</li>
+
+        <li>payment_links</li>
         </ul>
 
         <h2 id="authentication">Authentication</h2>
@@ -99,7 +101,22 @@
 
         <p>A successful call to payment_methods will return a list of supported payment methods along with redirect URL's so that you can send your shoppers directly to the issuer's site without losing control of front-end styling / logic.</p>
 
+        You can also create a link to Adyen's hosted payment form:
+
+        <pre><code class="ruby language-ruby">response = adyen.checkout.payment_links('{
+  "amount": {
+    "value": 1500,
+    "currency": "EUR"
+  },
+  "countryCode": "US",
+  "merchantAccount": "YOUR_MERCHANT_ACCOUNT",
+  "reference": "YOUR_REFERENCE"
+}')</code></pre>
+
+        <p>A successful call to payment_links will return a url, which directs a user to Adyen's hosted payment form.</p>
       </section>
+
+
       <footer>
         <p>This project is maintained by <a href="https://github.com/Adyen">Adyen</a></p>
         <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>

--- a/lib/adyen/services/checkout.rb
+++ b/lib/adyen/services/checkout.rb
@@ -8,7 +8,8 @@ module Adyen
       service = 'Checkout'
       method_names = [
         :payment_methods,
-        :payment_session
+        :payment_session,
+        :payment_links
       ]
 
       super(client, version, service, method_names)

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Adyen::Checkout, service: "checkout" do
   # format is defined in spec_helper
   test_sets = [
     ["payment_session", "publicKeyToken", "8115054323780109"],
+    ["payment_links", "url", "https://checkoutshopper-test.adyen.com"],
     ["payments", "resultCode", "Authorised"]
   ]
 

--- a/spec/mocks/requests/Checkout/payment_links.json
+++ b/spec/mocks/requests/Checkout/payment_links.json
@@ -1,0 +1,9 @@
+{
+  "amount": {
+    "currency": "USD",
+    "value": 1000
+  },
+  "countryCode": "US",
+  "merchantAccount": "TestMerchant",
+  "reference": "Merchant Reference"
+}

--- a/spec/mocks/responses/Checkout/payment_links.json
+++ b/spec/mocks/responses/Checkout/payment_links.json
@@ -1,0 +1,9 @@
+{
+  "amount": {
+    "currency": "USD",
+    "value": 1000
+  },
+  "expiresAt": "2019-12-14T10:05:29Z",
+  "reference": "Merchant Reference",
+  "url": "https://checkoutshopper-test.adyen.com"
+}

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Adyen::Service do
       expect(described_class.action_for_method_name(:origin_keys)).to eq 'originKeys'
       expect(described_class.action_for_method_name(:payment_methods)).to eq 'paymentMethods'
       expect(described_class.action_for_method_name(:payment_session)).to eq 'paymentSession'
+      expect(described_class.action_for_method_name(:payment_links)).to eq 'paymentLinks'
       expect(described_class.action_for_method_name(:refund)).to eq 'refund'
       expect(described_class.action_for_method_name(:store_detail)).to eq 'storeDetail'
       expect(described_class.action_for_method_name(:store_detail_and_submit_third_party)).to eq 'storeDetailAndSubmitThirdParty'


### PR DESCRIPTION
This PR will add the Pay by Link functionality as described in documentation: https://docs.adyen.com/api-explorer/#/PaymentSetupAndVerificationService/v50/paymentLinks

I've updated the documentation. Added a rspec test, that checks for URL in the response.