### PR TITLE
Add Data Protection Service API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Library supports all APIs under the following services:
 * recurring
 * marketpay
 * postfmapi
+* data_protection
 
 ## Requirements
 
@@ -145,6 +146,9 @@ adyen.checkout.version = 50
 - assign_terminals
 - find_terminal
 - get_terminals_under_account
+
+**data_protection:**
+- request_subject_erasure
 
 ## Support
 

--- a/lib/adyen-ruby-api-library.rb
+++ b/lib/adyen-ruby-api-library.rb
@@ -9,6 +9,7 @@ require_relative "adyen/services/recurring"
 require_relative "adyen/services/marketpay"
 require_relative "adyen/services/postfmapi"
 require_relative "adyen/services/service"
+require_relative "adyen/services/data_protection"
 require_relative "adyen/hash_with_accessors"
 require_relative "adyen/utils/hmac_validator"
 

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -54,6 +54,9 @@ module Adyen
         when "Terminal"
           url = "https://postfmapi-#{@env}.adyen.com/postfmapi/terminal"
           supports_live_url_prefix = false
+        when "DataProtectionService"
+          url = "https://ca-#{@env}.adyen.com/ca/services"
+          supports_live_url_prefix = false
         else
           raise ArgumentError, "Invalid service specified"
         end
@@ -193,6 +196,10 @@ module Adyen
 
     def postfmapi
       @postfmapi ||= Adyen::PosTerminalManagement.new(self)
+    end
+
+    def data_protection
+      @data_protection ||= Adyen::DataProtection.new(self)
     end
   end
 end

--- a/lib/adyen/services/data_protection.rb
+++ b/lib/adyen/services/data_protection.rb
@@ -1,0 +1,17 @@
+require_relative 'service'
+
+module Adyen
+  class DataProtection < Service
+    attr_accessor :version
+    DEFAULT_VERSION = 1
+
+    def initialize(client, version = DEFAULT_VERSION)
+      service = 'DataProtectionService'
+      method_names = [
+        :request_subject_erasure
+      ]
+
+      super(client, version, service, method_names)
+    end
+  end
+end

--- a/spec/data_protection_spec.rb
+++ b/spec/data_protection_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe Adyen::DataProtection, service: "Data Protection Service" do
+  # client instance to be used in dynamically generated tests
+  client = create_client(:basic)
+
+  # methods / values to test for
+  # format is defined in spec_helper
+  test_sets = [
+    ["request_subject_erasure", "result", "SUCCESS"],
+  ]
+
+  generate_tests(client, "DataProtectionService", test_sets, client.data_protection)
+end

--- a/spec/mocks/requests/DataProtectionService/request_subject_erasure.json
+++ b/spec/mocks/requests/DataProtectionService/request_subject_erasure.json
@@ -1,0 +1,5 @@
+{
+  "merchantAccount": "test_merchant",
+  "pspReference": "test_reference",
+  "forceErasure": true
+}

--- a/spec/mocks/responses/DataProtectionService/request_subject_erasure.json
+++ b/spec/mocks/responses/DataProtectionService/request_subject_erasure.json
@@ -1,0 +1,3 @@
+{
+  "result": "SUCCESS"
+}


### PR DESCRIPTION
Support [Data Protection API](https://docs.adyen.com/development-resources/data-protection-api) for GDPR removal of user associated info:
- `requestSubjectErasure`

Add unit test, and run and pass the following integration test locally:

```
require_relative 'lib/adyen-ruby-api-library'

adyen = Adyen::Client.new
adyen.api_key = 'API_KEY'
adyen.env = :test

params = {
  merchantAccount: 'MERCHANT_ACCOUNT',
  pspReference: 'PSP_REF',
  forceErasure: true,
}

response = adyen.data_protection.request_subject_erasure(params)
puts response.response['result']
```