### PR TITLE
Remove String.to_camel_case

### DIFF
--- a/lib/adyen-ruby-api-library.rb
+++ b/lib/adyen-ruby-api-library.rb
@@ -12,14 +12,3 @@ require_relative "adyen/services/service"
 require_relative "adyen/services/data_protection"
 require_relative "adyen/hash_with_accessors"
 require_relative "adyen/utils/hmac_validator"
-
-# add snake case to camel case converter to String
-# to convert rubinic method names to Adyen API methods
-#
-# i.e. snake_case -> snakeCase
-# note that the first letter is not capitalized as normal
-class String
-  def to_camel_case
-    split("_").collect.with_index{ |x, i| i > 0 ? x.capitalize : x }.join
-  end
-end


### PR DESCRIPTION
Completing Dana's modifications to not modify core classes - it's already an orphaned method which isn't actually used.