### PR TITLE
Renaming master to main in doc files and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you have a feature request, or spotted a bug or a technical problem, [create 
 For other questions, [contact our Support Team](https://www.adyen.help/hc/en-us/requests/new?ticket_form_id=360000705420).
 
 ## Licence
-This repository is available under the [MIT license](https://github.com/Adyen/adyen-ruby-api-library/blob/master/LICENSE).
+This repository is available under the [MIT license](https://github.com/Adyen/adyen-ruby-api-library/blob/main/LICENSE).
 
 ## See also
 * [Example integration](https://github.com/adyen-examples/adyen-rails-online-payments)

--- a/docs/checkout.html
+++ b/docs/checkout.html
@@ -23,8 +23,8 @@
 
       <p class="view"><a href="https://github.com/Adyen/adyen-ruby-api-library">View the Project on GitHub <small>Adyen/adyen-ruby-api-library</small></a></p>
         <ul>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/master">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/main">Download <strong>ZIP File</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/main">Download <strong>TAR Ball</strong></a></li>
           <li><a href="https://github.com/Adyen/adyen-ruby-api-library">View On <strong>GitHub</strong></a></li>
         </ul>
       </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,8 +21,8 @@
         <p class="view"><a href="https://github.com/Adyen/adyen-ruby-api-library">View the Project on GitHub <small>Adyen/adyen-ruby-api-library</small></a></p>
 
         <ul>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/master">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/main">Download <strong>ZIP File</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/main">Download <strong>TAR Ball</strong></a></li>
           <li><a href="https://github.com/Adyen/adyen-ruby-api-library">View On <strong>GitHub</strong></a></li>
         </ul>
       </header>

--- a/docs/install-library.html
+++ b/docs/install-library.html
@@ -25,8 +25,8 @@
 
 
         <ul>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/master">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/main">Download <strong>ZIP File</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/main">Download <strong>TAR Ball</strong></a></li>
           <li><a href="https://github.com/Adyen/adyen-ruby-api-library">View On <strong>GitHub</strong></a></li>
         </ul>
       </header>

--- a/docs/marketpay.html
+++ b/docs/marketpay.html
@@ -23,8 +23,8 @@
 
       <p class="view"><a href="https://github.com/Adyen/adyen-ruby-api-library">View the Project on GitHub <small>Adyen/adyen-ruby-api-library</small></a></p>
         <ul>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/master">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/main">Download <strong>ZIP File</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/main">Download <strong>TAR Ball</strong></a></li>
           <li><a href="https://github.com/Adyen/adyen-ruby-api-library">View On <strong>GitHub</strong></a></li>
         </ul>
       </header>

--- a/docs/payment.html
+++ b/docs/payment.html
@@ -24,8 +24,8 @@
 
       <p class="view"><a href="https://github.com/Adyen/adyen-ruby-api-library">View the Project on GitHub <small>Adyen/adyen-ruby-api-library</small></a></p>
         <ul>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/master">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/main">Download <strong>ZIP File</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/main">Download <strong>TAR Ball</strong></a></li>
           <li><a href="https://github.com/Adyen/adyen-ruby-api-library">View On <strong>GitHub</strong></a></li>
         </ul>
       </header>

--- a/docs/payout.html
+++ b/docs/payout.html
@@ -23,8 +23,8 @@
 
       <p class="view"><a href="https://github.com/Adyen/adyen-ruby-api-library">View the Project on GitHub <small>Adyen/adyen-ruby-api-library</small></a></p>
         <ul>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/master">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/main">Download <strong>ZIP File</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/main">Download <strong>TAR Ball</strong></a></li>
           <li><a href="https://github.com/Adyen/adyen-ruby-api-library">View On <strong>GitHub</strong></a></li>
         </ul>
       </header>

--- a/docs/recurring.html
+++ b/docs/recurring.html
@@ -23,8 +23,8 @@
 
       <p class="view"><a href="https://github.com/Adyen/adyen-ruby-api-library">View the Project on GitHub <small>Adyen/adyen-ruby-api-library</small></a></p>
         <ul>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/master">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/main">Download <strong>ZIP File</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/main">Download <strong>TAR Ball</strong></a></li>
           <li><a href="https://github.com/Adyen/adyen-ruby-api-library">View On <strong>GitHub</strong></a></li>
         </ul>
       </header>

--- a/docs/using-library.html
+++ b/docs/using-library.html
@@ -25,8 +25,8 @@
 
 
         <ul>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/master">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/zipball/main">Download <strong>ZIP File</strong></a></li>
+          <li><a href="https://github.com/Adyen/adyen-ruby-api-library/tarball/main">Download <strong>TAR Ball</strong></a></li>
           <li><a href="https://github.com/Adyen/adyen-ruby-api-library">View On <strong>GitHub</strong></a></li>
         </ul>
       </header>


### PR DESCRIPTION
## Summary
The `master` branch in this repo has been renamed to `main`.