### PR TITLE
Update syntax to work with faraday 2.0

### DIFF
--- a/adyen-ruby-api-library.gemspec
+++ b/adyen-ruby-api-library.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files`.split("\n")
 
-  spec.add_dependency 'faraday', '~> 2.0'
+  spec.add_dependency 'faraday'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'webmock'

--- a/adyen-ruby-api-library.gemspec
+++ b/adyen-ruby-api-library.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files`.split("\n")
 
-  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday', '~> 2.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'webmock'

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -104,7 +104,7 @@ module Adyen
         # set auth type based on service
         case auth_type
         when "basic"
-          faraday.basic_auth(@ws_user, @ws_password)
+          faraday.request :authorization, :basic, @ws_user, @ws_password
         when "api-key"
           faraday.headers["x-api-key"] = @api_key
         end
@@ -132,7 +132,7 @@ module Adyen
       if action.is_a?(::Hash)
         if action.fetch(:method) == "get"
           begin
-            response = conn.get 
+            response = conn.get
           rescue Faraday::ConnectionFailed => connection_error
             raise connection_error, "Connection to #{url} failed"
           end

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -104,7 +104,13 @@ module Adyen
         # set auth type based on service
         case auth_type
         when "basic"
-          faraday.request :authorization, :basic, @ws_user, @ws_password
+          if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
+            # for faraday 2.0 and higher
+            faraday.request :authorization, :basic, @ws_user, @ws_password
+          else
+            # for faraday 1.x
+            faraday.basic_auth(@ws_user, @ws_password)
+          end
         when "api-key"
           faraday.headers["x-api-key"] = @api_key
         end


### PR DESCRIPTION
**Description**
This library was not yet optimised for the faraday 2.0 gem which caused failed specs. This pull request fix the issues using this [guide](https://lostisland.github.io/faraday/middleware/authentication). 
