### PR TITLE
Add Apple Pay sessions endpoint to Checkout

### DIFF
--- a/lib/adyen/services/checkout.rb
+++ b/lib/adyen/services/checkout.rb
@@ -67,6 +67,17 @@ module Adyen
         @client.call_adyen_api(@service, action, args[0], args[1], @version)
       end
     end
+
+    def apple_pay(*args)
+      case args.size
+      when 0
+        Adyen::CheckoutApplePay.new(@client, @version)
+      else
+        action = "applePay"
+        args[1] ||= {}  # optional headers arg
+        @client.call_adyen_api(@service, action, args[0], args[1], @version)
+      end
+    end
   end
 
   class CheckoutDetail < Service
@@ -127,6 +138,19 @@ module Adyen
 
     def cancel(request, headers = {})
       action = "orders/cancel"
+      @client.call_adyen_api(@service, action, request, headers, @version)
+    end
+  end
+
+  class CheckoutApplePay < Service
+    def initialize(client, version = DEFAULT_VERSION)
+      @service = "Checkout"
+      @client = client
+      @version = version
+    end
+
+    def sessions(request, headers = {})
+      action = "applePay/sessions"
       @client.call_adyen_api(@service, action, request, headers, @version)
     end
   end

--- a/lib/adyen/services/checkout.rb
+++ b/lib/adyen/services/checkout.rb
@@ -68,15 +68,8 @@ module Adyen
       end
     end
 
-    def apple_pay(*args)
-      case args.size
-      when 0
-        Adyen::CheckoutApplePay.new(@client, @version)
-      else
-        action = "applePay"
-        args[1] ||= {}  # optional headers arg
-        @client.call_adyen_api(@service, action, args[0], args[1], @version)
-      end
+    def apple_pay
+      @apple_pay ||= Adyen::CheckoutApplePay.new(@client, @version)
     end
   end
 

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -345,6 +345,38 @@ RSpec.describe Adyen::Checkout, service: "checkout" do
       to eq("cancelled")
   end
 
+  it "makes an applePay/sessions call" do
+    request_body = JSON.parse(json_from_file("mocks/requests/Checkout/apple_pay_sessions.json"))
+
+    response_body = json_from_file("mocks/responses/Checkout/apple_pay_sessions.json")
+
+    url = @shared_values[:client].service_url(@shared_values[:service], "applePay/sessions", @shared_values[:client].checkout.version)
+    WebMock.stub_request(:post, url).
+      with(
+        body: request_body,
+        headers: {
+          "x-api-key" => @shared_values[:client].api_key
+        }
+      ).
+      to_return(
+        body: response_body
+      )
+
+    result = @shared_values[:client].checkout.apple_pay.sessions(request_body)
+    response_hash = result.response
+
+    expect(result.status).
+      to eq(200)
+    expect(response_hash).
+      to eq(JSON.parse(response_body))
+    expect(response_hash).
+      to be_a Adyen::HashWithAccessors
+    expect(response_hash).
+      to be_a_kind_of Hash
+    expect(response_hash["data"]).
+      to eq("LARGE_BLOB_HERE")
+  end
+
   it "makes a sessions call" do
     request_body = JSON.parse(json_from_file("mocks/requests/Checkout/sessions.json"))
 

--- a/spec/mocks/requests/Checkout/apple_pay_sessions.json
+++ b/spec/mocks/requests/Checkout/apple_pay_sessions.json
@@ -1,0 +1,5 @@
+{
+    "displayName": "YOUR_MERCHANT_NAME",
+    "domainName": "window.location.hostname",
+    "merchantIdentifier": "YOUR_MERCHANT_ID"
+}

--- a/spec/mocks/responses/Checkout/apple_pay_sessions.json
+++ b/spec/mocks/responses/Checkout/apple_pay_sessions.json
@@ -1,0 +1,3 @@
+{
+   "data" : "LARGE_BLOB_HERE"
+}


### PR DESCRIPTION
**Description**
* Introduce CheckoutApplePay under Checkout (checkout.apple_pay)
* Add test case that verifies the correct endpoint is called

This endpoint is needed for https://docs.adyen.com/payment-methods/apple-pay/api-only?tab=adyen-certificate-validation_1#complete-apple-pay-session-validation.

**Tested scenarios**
* Correct endpoint is reached (automated test)
* Expected result is coming back (manual test by invoking the method on actual Adyen TEST environment with correct request data)

**Fixed issue**:  N/A.
