### PR TITLE
Mask fields when request is string

### DIFF
--- a/lib/adyen/errors.rb
+++ b/lib/adyen/errors.rb
@@ -3,7 +3,10 @@ module Adyen
     attr_reader :code, :response, :request, :msg
 
     def initialize(request = nil, response = nil, msg = nil, code = nil)
-      mask_fields(request)
+      unless request.nil?
+        request = request.is_a?(Hash) ? request : JSON.parse(request, symbolize_names: true)
+        mask_fields(request)
+      end
 
       # components of formatted error message
       attributes = {
@@ -37,7 +40,7 @@ module Adyen
       ]
 
       # convert to hash if necessary
-      request = request.is_a?(Hash) ? request : JSON.parse(request)
+      request = request.is_a?(Hash) ? request : JSON.parse(request, symbolize_names: true)
 
       # iterate through request to find fields to mask
       request.each do |k, v|

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -43,5 +43,14 @@ RSpec.describe Adyen::AdyenError do
     it 'masks CVC when logging request in errors' do
       expect(Adyen::AdyenError.new(@shared_values[:request], 'response', 'message', 'code').request[:paymentMethod][:cvc]).to eq('***')
     end
+
+    context 'when request is string' do
+      it 'masks card number when logging request in errors' do
+        expect(Adyen::AdyenError.new(JSON.generate(@shared_values[:request]), 'response', 'message', 'code').request[:paymentMethod][:number]).to eq('411111******1111')
+      end
+      it 'masks CVC when logging request in errors' do
+        expect(Adyen::AdyenError.new(JSON.generate(@shared_values[:request]), 'response', 'message', 'code').request[:paymentMethod][:cvc]).to eq('***')
+      end
+    end
   end
 end


### PR DESCRIPTION
**Description**
Mask sensitive fields when request is a string. The only times I have managed to see request come in as a string is when Adyen web service user has a missing permission.
<img width="688" alt="image" src="https://user-images.githubusercontent.com/1313863/179743260-48a07818-f62d-4d3b-acbf-e1418236d44e.png">

Due to the fact that we parse request string into a hash inside of the `mask_fields` method, the current code doesn't modify the original request and it preserves the original request data without masking any of the fields. 

Additionally, while parsing it wasn't symbolising the name which meant, further down we were comparing string with symbols [here](https://github.com/Adyen/adyen-ruby-api-library/compare/develop...rabinshr:adyen-ruby-api-library:request-fix?expand=1#diff-ac9f61ff59687996b8d84adde53f7f3c0bf37dc88db5efb492da04abd94a6195R51)


**Tested scenarios**
- screenshot showing request is actually masked even when it is a string
![image](https://user-images.githubusercontent.com/1313863/179743429-3afcc5c2-d9da-46d4-be30-ec19bae752f5.png)
- added unit tests to cover request is a string scenario

**Fixed issue**:  <!-- #-prefixed issue number -->
