### PR TITLE
Support customizable Faraday connection options

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -6,9 +6,9 @@ require_relative "./result"
 module Adyen
   class Client
     attr_accessor :ws_user, :ws_password, :api_key, :client, :adapter, :live_url_prefix
-    attr_reader :env
+    attr_reader :env, :connection_options
 
-    def initialize(ws_user: nil, ws_password: nil, api_key: nil, env: :live, adapter: nil, mock_port: 3001, live_url_prefix: nil, mock_service_url_base: nil)
+    def initialize(ws_user: nil, ws_password: nil, api_key: nil, env: :live, adapter: nil, mock_port: 3001, live_url_prefix: nil, mock_service_url_base: nil, connection_options: nil)
       @ws_user = ws_user
       @ws_password = ws_password
       @api_key = api_key
@@ -16,6 +16,7 @@ module Adyen
       @adapter = adapter || Faraday.default_adapter
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       @live_url_prefix = live_url_prefix
+      @connection_options = connection_options || Faraday::ConnectionOptions.new
     end
 
     # make sure that env can only be :live, :test, or :mock
@@ -96,7 +97,7 @@ module Adyen
       end
 
       # initialize Faraday connection object
-      conn = Faraday.new(url: url) do |faraday|
+      conn = Faraday.new(url, @connection_options) do |faraday|
         faraday.adapter @adapter
         faraday.headers["Content-Type"] = "application/json"
         faraday.headers["User-Agent"] = Adyen::NAME + "/" + Adyen::VERSION


### PR DESCRIPTION
**Description**
Allow for more customizable `Faraday::ConnectionOptions` when calling Adyen's API.

At a high level, our set-up (and perhaps that of other future partners of Adyen) leverages a third-party vaulting provider for tokenization. In order to use the vaulting provider's offering, we need to be able to proxy requests through them first, before they forward the request over to Adyen.

In doing so, the Adyen client has been updated here to accept a customizable set of Faraday connection options to pass along to Faraday.

**Tested scenarios**
- Defaults to what was happening before, if no options are provided, with `Faraday::ConnectionOptions.new`.
- The Faraday connection is created with the options that are passed in.

**Fixed issue**:  I have not created a GH issue for this feature request, but can if required.
