### PR TITLE
[PW-7545] Remove Unnecessary Escaping for Notifications

### DIFF
--- a/lib/adyen/utils/hmac_validator.rb
+++ b/lib/adyen/utils/hmac_validator.rb
@@ -22,16 +22,15 @@ module Adyen
       end
 
       def data_to_sign(notification_request_item)
-        NOTIFICATION_VALIDATION_KEYS.map { |key| fetch(notification_request_item, key).to_s }
-                                    .map { |value| value.gsub('\\', '\\\\').gsub(':', '\\:') }
+        data = NOTIFICATION_VALIDATION_KEYS.map { |key| fetch(notification_request_item, key).to_s }
                                     .join(DATA_SEPARATOR)
+        return data
       end
 
       private
 
       def fetch(hash, keys)
         value = hash
-
         keys.to_s.split('.').each do |key|
           value = if key.to_i.to_s == key
                     value[key.to_i]

--- a/lib/adyen/version.rb
+++ b/lib/adyen/version.rb
@@ -1,4 +1,4 @@
 module Adyen
   NAME = "adyen-ruby-api-library"
-  VERSION = "6.1.0".freeze
+  VERSION = "6.2.0".freeze
 end

--- a/spec/mocks/responses/Webhooks/backslash_notification.json
+++ b/spec/mocks/responses/Webhooks/backslash_notification.json
@@ -1,0 +1,41 @@
+{
+  "additionalData": {
+    "acquirerCode": "TestPmmAcquirer",
+    "acquirerReference": "DZMKWLXW6N6",
+    "authCode": "076181",
+    "avsResult": "5 No AVS data provided",
+    "avsResultRaw": "5",
+    "cardSummary": "1111",
+    "checkout.cardAddedBrand": "visa",
+    "cvcResult": "1 Matches",
+    "cvcResultRaw": "M",
+    "expiryDate": "03/2030",
+    "hmacSignature": "nIgT81gaB5oJpn2jPXupDq68iRo2wUlBsuYjtYfwKqo=",
+    "paymentMethod": "visa",
+    "refusalReasonRaw": "AUTHORISED",
+    "retry.attempt1.acquirer": "TestPmmAcquirer",
+    "retry.attempt1.acquirerAccount": "TestPmmAcquirerAccount",
+    "retry.attempt1.avsResultRaw": "5",
+    "retry.attempt1.rawResponse": "AUTHORISED",
+    "retry.attempt1.responseCode": "Approved",
+    "retry.attempt1.scaExemptionRequested": "lowValue",
+    "scaExemptionRequested": "lowValue"
+  },
+  "amount": {
+    "currency": "EUR",
+    "value": 1000
+  },
+  "eventCode": "AUTHORISATION",
+  "eventDate": "2023-01-09T16:27:29+01:00",
+  "merchantAccountCode": "AntoniStroinski",
+  "merchantReference": "\\\\slashes are fun",
+  "operations": [
+    "CANCEL",
+    "CAPTURE",
+    "REFUND"
+  ],
+  "paymentMethod": "visa",
+  "pspReference": "T7FD4VM4D3RZNN82",
+  "reason": "076181:1111:03/2030",
+  "success": "true"
+}

--- a/spec/mocks/responses/Webhooks/colon_notification.json
+++ b/spec/mocks/responses/Webhooks/colon_notification.json
@@ -1,0 +1,41 @@
+{
+    "additionalData": {
+      "acquirerCode": "TestPmmAcquirer",
+      "acquirerReference": "8NQH5BNF58M",
+      "authCode": "039404",
+      "avsResult": "5 No AVS data provided",
+      "avsResultRaw": "5",
+      "cardSummary": "1111",
+      "checkout.cardAddedBrand": "visa",
+      "cvcResult": "1 Matches",
+      "cvcResultRaw": "M",
+      "expiryDate": "03/2030",
+      "hmacSignature": "2EQYm7YJpKO4EtHSPu55SQTyWf8dkW5u2nD1tJFpViA=",
+      "paymentMethod": "visa",
+      "refusalReasonRaw": "AUTHORISED",
+      "retry.attempt1.acquirer": "TestPmmAcquirer",
+      "retry.attempt1.acquirerAccount": "TestPmmAcquirerAccount",
+      "retry.attempt1.avsResultRaw": "5",
+      "retry.attempt1.rawResponse": "AUTHORISED",
+      "retry.attempt1.responseCode": "Approved",
+      "retry.attempt1.scaExemptionRequested": "lowValue",
+      "scaExemptionRequested": "lowValue"
+    },
+    "amount": {
+      "currency": "EUR",
+      "value": 1000
+    },
+    "eventCode": "AUTHORISATION",
+    "eventDate": "2023-01-10T13:40:54+01:00",
+    "merchantAccountCode": "AntoniStroinski",
+    "merchantReference": ":slashes are fun",
+    "operations": [
+      "CANCEL",
+      "CAPTURE",
+      "REFUND"
+    ],
+    "paymentMethod": "visa",
+    "pspReference": "M8NB66SBZSGLNK82",
+    "reason": "039404:1111:03/2030",
+    "success": "true"
+  }

--- a/spec/mocks/responses/Webhooks/forwardslash_notification.json
+++ b/spec/mocks/responses/Webhooks/forwardslash_notification.json
@@ -1,0 +1,41 @@
+{
+    "amount": {
+      "value": 1000,
+      "currency": "EUR"
+    },
+    "reason": "087330:1111:03/2030",
+    "success": "true",
+    "eventCode": "AUTHORISATION",
+    "eventDate": "2023-01-10T13:37:30+01:00",
+    "operations": [
+      "CANCEL",
+      "CAPTURE",
+      "REFUND"
+    ],
+    "pspReference": "X3GWNS6KJ8NKGK82",
+    "paymentMethod": "visa",
+    "additionalData": {
+      "authCode": "087330",
+      "avsResult": "5 No AVS data provided",
+      "cvcResult": "1 Matches",
+      "expiryDate": "03/2030",
+      "cardSummary": "1111",
+      "acquirerCode": "TestPmmAcquirer",
+      "avsResultRaw": "5",
+      "cvcResultRaw": "M",
+      "hmacSignature": "9Z0xdpG9Xi3zcmXv14t/BvMBut77O/Xq9D4CQXSDUi4=",
+      "paymentMethod": "visa",
+      "refusalReasonRaw": "AUTHORISED",
+      "acquirerReference": "HHCCC326PH6",
+      "scaExemptionRequested": "lowValue",
+      "checkout.cardAddedBrand": "visa",
+      "retry.attempt1.acquirer": "TestPmmAcquirer",
+      "retry.attempt1.rawResponse": "AUTHORISED",
+      "retry.attempt1.avsResultRaw": "5",
+      "retry.attempt1.responseCode": "Approved",
+      "retry.attempt1.acquirerAccount": "TestPmmAcquirerAccount",
+      "retry.attempt1.scaExemptionRequested": "lowValue"
+    },
+    "merchantReference": "//slashes are fun",
+    "merchantAccountCode": "AntoniStroinski"
+  }

--- a/spec/mocks/responses/Webhooks/mixed_notification.json
+++ b/spec/mocks/responses/Webhooks/mixed_notification.json
@@ -1,0 +1,41 @@
+{
+    "additionalData": {
+      "acquirerCode": "TestPmmAcquirer",
+      "acquirerReference": "J8DXDJ2PV6P",
+      "authCode": "052095",
+      "avsResult": "5 No AVS data provided",
+      "avsResultRaw": "5",
+      "cardSummary": "1111",
+      "checkout.cardAddedBrand": "visa",
+      "cvcResult": "1 Matches",
+      "cvcResultRaw": "M",
+      "expiryDate": "03/2030",
+      "hmacSignature": "CZErGCNQaSsxbaQfZaJlakqo7KPP+mIa8a+wx3yNs9A=",
+      "paymentMethod": "visa",
+      "refusalReasonRaw": "AUTHORISED",
+      "retry.attempt1.acquirer": "TestPmmAcquirer",
+      "retry.attempt1.acquirerAccount": "TestPmmAcquirerAccount",
+      "retry.attempt1.avsResultRaw": "5",
+      "retry.attempt1.rawResponse": "AUTHORISED",
+      "retry.attempt1.responseCode": "Approved",
+      "retry.attempt1.scaExemptionRequested": "lowValue",
+      "scaExemptionRequested": "lowValue"
+    },
+    "amount": {
+      "currency": "EUR",
+      "value": 1000
+    },
+    "eventCode": "AUTHORISATION",
+    "eventDate": "2023-01-10T13:42:29+01:00",
+    "merchantAccountCode": "AntoniStroinski",
+    "merchantReference": "\\:/\\/slashes are fun",
+    "operations": [
+      "CANCEL",
+      "CAPTURE",
+      "REFUND"
+    ],
+    "paymentMethod": "visa",
+    "pspReference": "ZVWN7D3WSMK2WN82",
+    "reason": "052095:1111:03/2030",
+    "success": "true"
+  }


### PR DESCRIPTION
**Description**
Similarly to https://github.com/Adyen/adyen-python-api-library/pull/193, this PR removes the escaping and adds extra UTs to verify that it handles the special characters correctly.