### PR TITLE
[ITT-20] Checkout V70 new/missing endpoints

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -144,6 +144,13 @@ module Adyen
             raise connection_error, "Connection to #{url} failed"
           end
         end
+        if action.fetch(:method) == "delete"
+          begin
+            response = conn.delete
+          rescue Faraday::ConnectionFailed => connection_error
+            raise connection_error, "Connection to #{url} failed"
+          end
+        end
         if action.fetch(:method) == "patch"
           begin
             response = conn.patch do |req|
@@ -169,11 +176,16 @@ module Adyen
       when 401
         raise Adyen::AuthenticationError.new("Invalid API authentication; https://docs.adyen.com/user-management/how-to-get-the-api-key", request_data)
       when 403
-        raise Adyen::PermissionError.new("Missing user permissions; https://docs.adyen.com/user-management/user-roles", request_data, response.response_body)
+        raise Adyen::PermissionError.new("Missing user permissions; https://docs.adyen.com/user-management/user-roles", request_data, response.body)
       end
-
-      formatted_response = AdyenResult.new(response.body, response.headers, response.status)
-
+      
+      # delete has no response.body (unless it throws an error)
+      if response.body == nil
+        formatted_response = AdyenResult.new("{}", response.headers, response.status)
+      else
+        formatted_response = AdyenResult.new(response.body, response.headers, response.status)
+      end
+      
       formatted_response
     end
 

--- a/lib/adyen/services/checkout.rb
+++ b/lib/adyen/services/checkout.rb
@@ -2,7 +2,7 @@ require_relative "service"
 
 module Adyen
   class Checkout < Service
-    DEFAULT_VERSION = 68
+    DEFAULT_VERSION = 70
 
     def initialize(client, version = DEFAULT_VERSION)
       service = "Checkout"
@@ -12,9 +12,7 @@ module Adyen
         :sessions
       ]
 
-      with_application_info = [
-        :payment_session,
-      ]
+      with_application_info = []
 
       super(client, version, service, method_names, with_application_info)
     end
@@ -31,7 +29,7 @@ module Adyen
       else
         action = "payments"
         args[1] ||= {}  # optional headers arg
-        @client.call_adyen_api(@service, action, args[0], args[1], @version, true)
+        @client.call_adyen_api(@service, action, args[0], args[1], @version)
       end
     end
 
@@ -42,7 +40,7 @@ module Adyen
       else
         action = "paymentLinks"
         args[1] ||= {}  # optional headers arg
-        @client.call_adyen_api(@service, action, args[0], args[1], @version, true)
+        @client.call_adyen_api(@service, action, args[0], args[1], @version)
       end
     end
 
@@ -75,6 +73,10 @@ module Adyen
     def modifications
       @modifications ||= Adyen::Modifications.new(@client, @version)
     end
+
+    def stored_payment_methods
+      @stored_payment_methods ||= Adyen::StoredPaymentMethods.new(@client, @version)
+    end
   end
 
   class CheckoutDetail < Service
@@ -93,6 +95,16 @@ module Adyen
       action = "payments/result"
       @client.call_adyen_api(@service, action, request, headers, @version)
     end
+
+    def donations(request, headers = {})
+      action = "donations"
+      @client.call_adyen_api(@service, action, request, headers, @version)
+    end
+
+    def card_details(request, headers = {})
+      action = "cardDetails"
+      @client.call_adyen_api(@service, action, request, headers, @version)
+    end
   end
 
   class CheckoutLink < Service
@@ -104,12 +116,12 @@ module Adyen
 
     def get(linkId, headers = {})
       action = { method: 'get', url: "paymentLinks/" + linkId }
-      @client.call_adyen_api(@service, action, {}, headers, @version, true)
+      @client.call_adyen_api(@service, action, {}, headers, @version)
     end
 
     def update(linkId, request, headers = {})
       action = { method: 'patch', url: "paymentLinks/" + linkId }
-      @client.call_adyen_api(@service, action, request, headers, @version, false)
+      @client.call_adyen_api(@service, action, request, headers, @version)
     end
   end
 
@@ -122,7 +134,7 @@ module Adyen
 
     def balance(request, headers = {})
       action = "paymentMethods/balance"
-      @client.call_adyen_api(@service, action, request, headers, @version, true)
+      @client.call_adyen_api(@service, action, request, headers, @version, false)
     end
   end
 
@@ -161,12 +173,12 @@ module Adyen
 
     def capture(linkId, request, headers = {})
       action = "payments/" + linkId + "/captures"
-      @client.call_adyen_api(@service, action, request, headers, @version, false)
+      @client.call_adyen_api(@service, action, request, headers, @version)
     end
 
     def cancel(linkId, request, headers = {})
       action = "payments/" + linkId + "/cancels"
-      @client.call_adyen_api(@service, action, request, headers, @version, false)
+      @client.call_adyen_api(@service, action, request, headers, @version)
     end
 
     def genericCancel(request, headers = {})
@@ -176,17 +188,35 @@ module Adyen
   
     def refund(linkId, request, headers = {})
       action = "payments/" + linkId + "/refunds"
-      @client.call_adyen_api(@service, action, request, headers, @version, false)
+      @client.call_adyen_api(@service, action, request, headers, @version)
     end
 
     def reversal(linkId, request, headers = {})
       action = "payments/" + linkId + "/reversals"
-      @client.call_adyen_api(@service, action, request, headers, @version, false)
+      @client.call_adyen_api(@service, action, request, headers, @version)
     end
 
     def amountUpdate(linkId, request, headers = {})
       action = "payments/" + linkId + "/amountUpdates"
-      @client.call_adyen_api(@service, action, request, headers, @version, false)
+      @client.call_adyen_api(@service, action, request, headers, @version)
+    end
+  end
+
+  class StoredPaymentMethods < Service
+    def initialize(client, version = DEFAULT_VERSION)
+      @service = "Checkout"
+      @client = client
+      @version = version
+    end
+
+    def get(query_array={}, headers = {})
+      action = { method: 'get', url: "storedPaymentMethods" + create_query_string(query_array)}
+      @client.call_adyen_api(@service, action, {}, headers, @version)
+    end
+
+    def delete(recurringId, query_array={}, headers = {})
+      action = { method: 'delete', url: "storedPaymentMethods/%s" % recurringId + create_query_string(query_array)}
+      @client.call_adyen_api(@service, action, {}, headers, @version)
     end
   end
 end

--- a/lib/adyen/services/checkout.rb
+++ b/lib/adyen/services/checkout.rb
@@ -12,7 +12,9 @@ module Adyen
         :sessions
       ]
 
-      with_application_info = []
+      with_application_info = [
+        :payment_session
+      ]
 
       super(client, version, service, method_names, with_application_info)
     end
@@ -29,7 +31,7 @@ module Adyen
       else
         action = "payments"
         args[1] ||= {}  # optional headers arg
-        @client.call_adyen_api(@service, action, args[0], args[1], @version)
+        @client.call_adyen_api(@service, action, args[0], args[1], @version, true)
       end
     end
 
@@ -134,7 +136,7 @@ module Adyen
 
     def balance(request, headers = {})
       action = "paymentMethods/balance"
-      @client.call_adyen_api(@service, action, request, headers, @version, false)
+      @client.call_adyen_api(@service, action, request, headers, @version, true)
     end
   end
 

--- a/lib/adyen/services/service.rb
+++ b/lib/adyen/services/service.rb
@@ -24,5 +24,10 @@ module Adyen
         end
       end
     end
+
+    # create query parameter from an array
+    def create_query_string(arr)
+      "?" + URI.encode_www_form(arr)
+    end
   end
 end

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -597,6 +597,56 @@ RSpec.describe Adyen::Checkout, service: "checkout" do
       to eq("12345")
   end
 
+  it "makes a get storedPaymentMethods call" do
+    response_body = json_from_file("mocks/responses/Checkout/stored_payment_methods.json")
+
+    url = @shared_values[:client].service_url(@shared_values[:service], "storedPaymentMethods?merchantAccount=TestMerchantAccount&shopperReference=test-1234", @shared_values[:client].checkout.version)
+    WebMock.stub_request(:get, url).
+      with(
+        headers: {
+          "x-api-key" => @shared_values[:client].api_key
+        }
+      ).
+      to_return(
+        body: response_body
+      )
+
+    result = @shared_values[:client].checkout.stored_payment_methods.get({"merchantAccount" => "TestMerchantAccount", "shopperReference" => "test-1234"})
+    response_hash = result.response
+
+    expect(result.status).
+      to eq(200)
+    expect(response_hash).
+      to eq(JSON.parse(response_body))
+    expect(response_hash).
+      to be_a Adyen::HashWithAccessors
+    expect(response_hash).
+      to be_a_kind_of Hash
+    expect(response_hash["shopperReference"]).
+      to eq("test-1234")
+  end
+
+  it "makes a delete storedPaymentMethods call" do
+    response_body = json_from_file("mocks/responses/Checkout/stored_payment_methods.json")
+
+    url = @shared_values[:client].service_url(@shared_values[:service], "storedPaymentMethods/RL8FW7WZM6KXWD82?merchantAccount=TestMerchantAccount&shopperReference=test-1234", @shared_values[:client].checkout.version)
+    WebMock.stub_request(:delete, url).
+      with(
+        headers: {
+          "x-api-key" => @shared_values[:client].api_key
+        }
+      ).
+      to_return(
+        body: response_body
+      )
+
+    result = @shared_values[:client].checkout.stored_payment_methods.delete("RL8FW7WZM6KXWD82", {"merchantAccount" => "TestMerchantAccount", "shopperReference" => "test-1234"})
+    response_hash = result.response
+
+    expect(result.status).
+      to eq(200)
+  end
+
   # create client for automated tests
   client = create_client(:api_key)
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Adyen do
     mock_response = Faraday::Response.new(status: 200)
 
     expect(Adyen::AdyenResult).to receive(:new)
-    expect(Faraday).to receive(:new).with("http://localhost:3001/v68/payments/details", connection_options).and_return(mock_faraday_connection)
+    expect(Faraday).to receive(:new).with("http://localhost:3001/v70/payments/details", connection_options).and_return(mock_faraday_connection)
     expect(mock_faraday_connection).to receive(:post).and_return(mock_response)
     client.checkout.payments.details(request_body)
   end

--- a/spec/mocks/responses/Checkout/stored_payment_methods.json
+++ b/spec/mocks/responses/Checkout/stored_payment_methods.json
@@ -1,0 +1,1 @@
+{"merchantAccount":"TestMerchantAccount", "shopperReference":"test-1234"}


### PR DESCRIPTION
**Description**
This PR updates the checkout versioning to v70 (for which I needed to exclude the applications info). I added the new storedPaymentMethod endpoints and added two which were missing (donations/cardDetails). In the client.rb I had to introduce a new method for the delete request. 

**Tested scenarios**
Unit tests and tested all the endpoints locally via actual api calls.
