### PR TITLE
Refactor/hmac validator

### DIFF
--- a/lib/adyen/utils/hmac_validator.rb
+++ b/lib/adyen/utils/hmac_validator.rb
@@ -10,7 +10,8 @@ module Adyen
 
       def valid_webhook_hmac?(webhook_request_item, hmac_key)
         expected_sign = calculate_webhook_hmac(webhook_request_item, hmac_key)
-        merchant_sign = fetch(webhook_request_item, 'additionalData.hmacSignature')
+        merchant_sign =
+          webhook_request_item.dig('additionalData', 'hmacSignature')
 
         expected_sign == merchant_sign
       end
@@ -18,29 +19,17 @@ module Adyen
       def calculate_webhook_hmac(webhook_request_item, hmac_key)
         data = data_to_sign(webhook_request_item)
 
-        Base64.strict_encode64(OpenSSL::HMAC.digest(HMAC_ALGORITHM, [hmac_key].pack('H*'), data))
+        Base64.strict_encode64(
+          OpenSSL::HMAC.digest(HMAC_ALGORITHM, [hmac_key].pack('H*'), data)
+        )
       end
 
 
       def data_to_sign(webhook_request_item)
-        data = WEBHOOK_VALIDATION_KEYS.map { |key| fetch(webhook_request_item, key).to_s }
-                                    .join(DATA_SEPARATOR)
-      end
-
-      private
-
-      def fetch(hash, keys)
-        value = hash
-        keys.to_s.split('.').each do |key|
-          value = if key.to_i.to_s == key
-                    value[key.to_i]
-                  else
-                    value[key].nil? ? value[key.to_sym] : value[key]
-                  end
-          break if value.nil?
-        end
-
-        value
+        WEBHOOK_VALIDATION_KEYS
+          .map { webhook_request_item.dig(*_1.split('.')).to_s }
+          .compact
+          .join(DATA_SEPARATOR)
       end
     end
   end

--- a/lib/adyen/utils/hmac_validator.rb
+++ b/lib/adyen/utils/hmac_validator.rb
@@ -24,6 +24,9 @@ module Adyen
         )
       end
 
+      # TODO: Deprecate instead of aliasing
+      alias valid_notification_hmac? valid_webhook_hmac?
+      alias calculate_notification_hmac calculate_webhook_hmac
 
       def data_to_sign(webhook_request_item)
         WEBHOOK_VALIDATION_KEYS

--- a/spec/utils/hmac_validator_spec.rb
+++ b/spec/utils/hmac_validator_spec.rb
@@ -6,19 +6,19 @@ RSpec.describe Adyen::Utils::HmacValidator do
   let(:expected_sign) { 'coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0=' }
   let(:webhook_request_item) do
     {
-      additionalData: {
-        hmacSignature: expected_sign
+      'additionalData' => {
+        'hmacSignature' => expected_sign
       },
-      amount: {
-        value: 1130,
-        currency: 'EUR'
+      'amount' => {
+        'value' => 1130,
+        'currency' => 'EUR'
       },
-      pspReference: '7914073381342284',
-      eventCode: 'AUTHORISATION',
-      merchantAccountCode: 'TestMerchant',
-      merchantReference: 'TestPayment-1407325143704',
-      paymentMethod: 'visa',
-      success: 'true'
+      'pspReference' => '7914073381342284',
+      'eventCode' => 'AUTHORISATION',
+      'merchantAccountCode' => 'TestMerchant',
+      'merchantReference' => 'TestPayment-1407325143704',
+      'paymentMethod' => 'visa',
+      'success' => 'true'
     }
   end
 

--- a/spec/utils/hmac_validator_spec.rb
+++ b/spec/utils/hmac_validator_spec.rb
@@ -44,22 +44,22 @@ RSpec.describe Adyen::Utils::HmacValidator do
     end
 
     it 'should validate backslashes correctly' do
-      webhook = JSON.parse(json_from_file("mocks/responses/Webhooks/backslash_webhook.json"))
+      webhook = JSON.parse(json_from_file('mocks/responses/Webhooks/backslash_webhook.json'))
       expect(validator.valid_webhook_hmac?(webhook, '74F490DD33F7327BAECC88B2947C011FC02D014A473AAA33A8EC93E4DC069174')).to be true
     end
 
     it 'should validate colons correctly' do
-      webhook = JSON.parse(json_from_file("mocks/responses/Webhooks/colon_webhook.json"))
+      webhook = JSON.parse(json_from_file('mocks/responses/Webhooks/colon_webhook.json'))
       expect(validator.valid_webhook_hmac?(webhook, '74F490DD33F7327BAECC88B2947C011FC02D014A473AAA33A8EC93E4DC069174')).to be true
     end
 
     it 'should validate forward slashes correctly' do
-      webhook = JSON.parse(json_from_file("mocks/responses/Webhooks/forwardslash_webhook.json"))
+      webhook = JSON.parse(json_from_file('mocks/responses/Webhooks/forwardslash_webhook.json'))
       expect(validator.valid_webhook_hmac?(webhook, '74F490DD33F7327BAECC88B2947C011FC02D014A473AAA33A8EC93E4DC069174')).to be true
     end
 
     it 'should validate mix of slashes and colon correctly' do
-      webhook = JSON.parse(json_from_file("mocks/responses/Webhooks/mixed_webhook.json"))
+      webhook = JSON.parse(json_from_file('mocks/responses/Webhooks/mixed_webhook.json'))
       expect(validator.valid_webhook_hmac?(webhook, '74F490DD33F7327BAECC88B2947C011FC02D014A473AAA33A8EC93E4DC069174')).to be true
     end
   end


### PR DESCRIPTION
**Description**
Small refactoring on HmacValidator utility class. 

1. Replaced double quotes with singles in the test, for style.
2. Defined `webhook_request_item` with hash rocket style, using string keys, to match the json moced examples.
3. Refactored the validation logic to be a bit neater and more readable. 
This is a breaking change, however. With my proposed implementation hashes with symbolized keys will fail. The code expects string keys now. If maintainers think symbol keys are necessary, I can add the support back, but in a bit different style...
3. Added aliases on two public methods that recently changed names, for backward compatibility.

Didn't do any significant spec refactoring. I intend to commit to that with a separate PR. But before I do that, I wanted to hear maintainers' opinions on another change.
Currently, the validator needs to be instantiated to access those public instance methods. This, arguably, is unnecessary, as there is no useful internal state to the instance. On top of that, these methods are used as class methods - not referencing instance state. To make the instance useful, #new method should accept those arguments that are now passed to instance methods, memoized as instance variables, and public methods should access them without taking any arguments. 
But that would not improve much, I propose tho move those methods to class methods. 
A possible performance and memory improvement - as we would not need to instantiate a new object every time we need access to that logic. ::Adyen::Utils::HmacValidator is a constant object, and those methods should be accessible on it like so:
```ruby
::Adyen::Utils::HmacValidator.valid_notification_hmac?(item, hmac_key)
```
👆 dependency is also easier to stub in unit tests, so makes unit testing simpler.

This would actually be an improvement. A breaking change again, but for a good reason.

Please let me know what you think, I will be more than happy to contribute.
