### PR TITLE
fix adapter options for faraday 1.x, fixes #177

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -23,7 +23,13 @@ module Adyen
       @oauth_token = oauth_token
       @env = env
       @adapter = adapter || Faraday.default_adapter
-      @adapter_options = adapter_options || Faraday.default_adapter_options
+      if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
+        # for faraday 2.0 and higher
+        @adapter_options = adapter_options || Faraday.default_adapter_options
+      else
+        # for faraday 1.x
+        @adapter_options = adapter_options
+      end
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       @live_url_prefix = live_url_prefix
       @connection_options = connection_options || Faraday::ConnectionOptions.new

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -16,7 +16,7 @@ module Adyen
     attr_reader :env, :connection_options, :adapter_options
 
     def initialize(ws_user: nil, ws_password: nil, api_key: nil, oauth_token: nil, env: :live, adapter: nil, mock_port: 3001,
-                   live_url_prefix: nil, mock_service_url_base: nil, connection_options: nil, adapter_options: {})
+                   live_url_prefix: nil, mock_service_url_base: nil, connection_options: nil, adapter_options: nil)
       @ws_user = ws_user
       @ws_password = ws_password
       @api_key = api_key
@@ -28,7 +28,7 @@ module Adyen
         @adapter_options = adapter_options || Faraday.default_adapter_options
       else
         # for faraday 1.x
-        @adapter_options = adapter_options
+        @adapter_options = adapter_options || {}
       end
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       @live_url_prefix = live_url_prefix

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -23,11 +23,11 @@ module Adyen
       @oauth_token = oauth_token
       @env = env
       @adapter = adapter || Faraday.default_adapter
-      if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
-        # for faraday 2.0 and higher
+      if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.1')
+        # for faraday 2.1 and higher
         @adapter_options = adapter_options || Faraday.default_adapter_options
       else
-        # for faraday 1.x
+        # for faraday 1.x and 2.0
         @adapter_options = adapter_options || {}
       end
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -16,7 +16,7 @@ module Adyen
     attr_reader :env, :connection_options, :adapter_options
 
     def initialize(ws_user: nil, ws_password: nil, api_key: nil, oauth_token: nil, env: :live, adapter: nil, mock_port: 3001,
-                   live_url_prefix: nil, mock_service_url_base: nil, connection_options: nil, adapter_options: nil)
+                   live_url_prefix: nil, mock_service_url_base: nil, connection_options: nil, adapter_options: {})
       @ws_user = ws_user
       @ws_password = ws_password
       @api_key = api_key


### PR DESCRIPTION
**Description**
quick fix for adapter options for Faraday 1.x

**Tested scenarios**
paymentMethods call with Faraday 1.10 and with Faraday 2.x

**Fixed issue**:  #177
