### PR TITLE
Add support for the /me/generateClientKey endpoint

### DIFF
--- a/lib/adyen/services/management/my_api_credential_api.rb
+++ b/lib/adyen/services/management/my_api_credential_api.rb
@@ -11,7 +11,7 @@ module Adyen
       endpoint = '/me/allowedOrigins/{originId}'.gsub(/{.+?}/, '%s')
       endpoint = endpoint.gsub(%r{^/}, '')
       endpoint = format(endpoint, origin_id)
-      
+
       action = { method: 'delete', url: endpoint }
       @client.call_adyen_api(@service, action, {}, headers, @version)
     end
@@ -20,7 +20,7 @@ module Adyen
       endpoint = '/me'.gsub(/{.+?}/, '%s')
       endpoint = endpoint.gsub(%r{^/}, '')
       endpoint = format(endpoint)
-      
+
       action = { method: 'get', url: endpoint }
       @client.call_adyen_api(@service, action, {}, headers, @version)
     end
@@ -29,7 +29,7 @@ module Adyen
       endpoint = '/me/allowedOrigins'.gsub(/{.+?}/, '%s')
       endpoint = endpoint.gsub(%r{^/}, '')
       endpoint = format(endpoint)
-      
+
       action = { method: 'get', url: endpoint }
       @client.call_adyen_api(@service, action, {}, headers, @version)
     end
@@ -38,7 +38,7 @@ module Adyen
       endpoint = '/me/allowedOrigins/{originId}'.gsub(/{.+?}/, '%s')
       endpoint = endpoint.gsub(%r{^/}, '')
       endpoint = format(endpoint, origin_id)
-      
+
       action = { method: 'get', url: endpoint }
       @client.call_adyen_api(@service, action, {}, headers, @version)
     end
@@ -47,9 +47,18 @@ module Adyen
       endpoint = '/me/allowedOrigins'.gsub(/{.+?}/, '%s')
       endpoint = endpoint.gsub(%r{^/}, '')
       endpoint = format(endpoint)
-      
+
       action = { method: 'post', url: endpoint }
       @client.call_adyen_api(@service, action, request, headers, @version)
+    end
+
+    def generate_client_key(headers: {})
+      endpoint = '/me/generateClientKey'.gsub(/{.+?}/, '%s')
+      endpoint = endpoint.gsub(%r{^/}, '')
+      endpoint = format(endpoint)
+
+      action = { method: 'post', url: endpoint }
+      @client.call_adyen_api(@service, action, {}, headers, @version)
     end
 
   end


### PR DESCRIPTION
**Description**
Added support for the `/me/generateClientKey` endpoint as described in the [OAuth docs](https://docs.adyen.com/development-resources/oauth/scopes/#step-2-generate-a-client-key). 

Tested this locally and was able to generate a clientKey