### PR TITLE
[Bugfix] Use Data Protection service name that matches the `Adyen::Client#service_url_base` 

### DIFF
--- a/lib/adyen/services/dataProtection.rb
+++ b/lib/adyen/services/dataProtection.rb
@@ -5,7 +5,7 @@ module Adyen
 
     DEFAULT_VERSION = 1
     def initialize(client, version = DEFAULT_VERSION)
-      super(client, version, 'DataProtection')
+      super(client, version, 'DataProtectionService')
     end
 
     def request_subject_erasure(request, headers: {})


### PR DESCRIPTION
When trying to run `.data_protection.request_subject_erasure({ merchantAccount: 'blurred', pspReference: 'blorred' })` the service throws `ArgumentError: Invalid service specified`.

Looking into the source code I found out that this was caused by `Adyen::Client#service_url_base` expecting "DataProtectionService". However in `Adyen::DataProtection->initialize`, the "DataProtection" string was used as a service name.