### PR TITLE
HMAC validation bank webhooks

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -33,8 +33,6 @@ module Adyen
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       @live_url_prefix = live_url_prefix
       @connection_options = connection_options || Faraday::ConnectionOptions.new
-
-      puts "Initialize Adyen Ruby client!!"
     end
 
     # make sure that env can only be :live, :test, or :mock

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -33,6 +33,8 @@ module Adyen
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       @live_url_prefix = live_url_prefix
       @connection_options = connection_options || Faraday::ConnectionOptions.new
+
+      puts "Initialize Adyen Ruby client!!"
     end
 
     # make sure that env can only be :live, :test, or :mock

--- a/lib/adyen/services/checkout/payments_api.rb
+++ b/lib/adyen/services/checkout/payments_api.rb
@@ -57,8 +57,6 @@ module Adyen
       endpoint = endpoint.gsub(%r{^/}, '')
       endpoint = format(endpoint)
 
-      puts "/sessions"
-      
       action = { method: 'post', url: endpoint }
       @client.call_adyen_api(@service, action, request, headers, @version)
     end

--- a/lib/adyen/services/checkout/payments_api.rb
+++ b/lib/adyen/services/checkout/payments_api.rb
@@ -56,6 +56,8 @@ module Adyen
       endpoint = '/sessions'.gsub(/{.+?}/, '%s')
       endpoint = endpoint.gsub(%r{^/}, '')
       endpoint = format(endpoint)
+
+      puts "/sessions"
       
       action = { method: 'post', url: endpoint }
       @client.call_adyen_api(@service, action, request, headers, @version)

--- a/lib/adyen/utils/hmac_validator.rb
+++ b/lib/adyen/utils/hmac_validator.rb
@@ -13,6 +13,13 @@ module Adyen
         valid_webhook_hmac?(notification_request_item, hmac_key)
       end
 
+      # validates the HMAC signature of the NotificationRequestItem object. Use for webhooks that provide the
+      # hmacSignature as part of the payload `AdditionalData` (i.e. Payments)
+      #
+      # @param webhook_request_item [Object] The webhook request item.
+      # @param hmac_key [String] The HMAC key used to validate the payload.
+      
+      # @return [Boolean] Returns true if the HMAC signature is valid, otherwise false.      
       def valid_webhook_hmac?(webhook_request_item, hmac_key)
         expected_sign = calculate_webhook_hmac(webhook_request_item, hmac_key)
         merchant_sign =
@@ -21,12 +28,32 @@ module Adyen
         expected_sign == merchant_sign
       end
 
+      # validates the HMAC signature of a payload against an expected signature. Use for webhooks that provide the
+      # hmacSignature in the HTTP header (i.e. Banking, Management API)
+      #
+      # @param hmac_signature [String] The HMAC signature to validate.
+      # @param hmac_key [String] The HMAC key used to validate the payload.
+      # @param payload [String] The webhook payload.
+
+      # @return [Boolean] Returns true if the HMAC signature is valid, otherwise false.      
+      def valid_webhook_payload_hmac?(hmac_signature, hmac_key, payload)
+        expected_sign = calculate_webhook_payload_hmac(payload, hmac_key)
+        puts(expected_sign)
+        expected_sign == hmac_signature
+      end
+
       # <b>DEPRECATED:</b> Please use calculate_webhook_hmac() instead.
       def calculate_notification_hmac(notification_request_item, hmac_key)
         calculate_webhook_hmac(notification_request_item, hmac_key)
       end
 
     
+      def calculate_webhook_payload_hmac(data, hmac_key)
+        Base64.strict_encode64(
+          OpenSSL::HMAC.digest(HMAC_ALGORITHM, [hmac_key].pack('H*'), data)
+        )
+      end
+
       def calculate_webhook_hmac(webhook_request_item, hmac_key)
         data = data_to_sign(webhook_request_item)
 
@@ -34,6 +61,7 @@ module Adyen
           OpenSSL::HMAC.digest(HMAC_ALGORITHM, [hmac_key].pack('H*'), data)
         )
       end
+
 
       # TODO: Deprecate instead of aliasing
       alias valid_notification_hmac? valid_webhook_hmac?

--- a/spec/utils/hmac_validator_spec.rb
+++ b/spec/utils/hmac_validator_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe Adyen::Utils::HmacValidator do
       webhook = JSON.parse(json_from_file('mocks/responses/Webhooks/mixed_webhook.json'))
       expect(validator.valid_webhook_hmac?(webhook, '74F490DD33F7327BAECC88B2947C011FC02D014A473AAA33A8EC93E4DC069174')).to be true
     end
+
+    it 'should have an invalid payload hmac' do
+      hmac_signature = "wrong signature"
+      payload = json_from_file('mocks/responses/Webhooks/mixed_webhook.json')
+
+      expect(validator.valid_webhook_payload_hmac?(hmac_signature, key, payload)).to be false
+    end
+
+    it 'should have an valid payload hmac' do
+      hmac_signature = "93Av9t6OVkYCrVHU/xgiTkWGbulJz+Vcm2qO4TYQH2Q="
+      payload = json_from_file('mocks/responses/Webhooks/mixed_webhook.json')
+
+      expect(validator.valid_webhook_payload_hmac?(hmac_signature, key, payload)).to be true
+    end
+
   end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## Summary
The library provides only support for validating webhook payloads that include the HMAC signature in the request body `AdditionalData` (i.e. standard webhooks).  
This PR adds a method to validate the webhook payloads that include the HMAC signature in the HTTP header (.i.e banking webhooks).

## Tested scenarios
Added unit testing, tested with the [Adyen Sample app](https://github.com/adyen-examples/adyen-rails-online-payments) (note: I have created a temporary branch as we don't have a Ruby sample app for AfP)
