### PR TITLE
added new issue labeler and stalebot

### DIFF
--- a/.github/workflows/label_new_issues.yml
+++ b/.github/workflows/label_new_issues.yml
@@ -1,0 +1,14 @@
+name: Label New Issues
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add 'needs response' label to new issues
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'needs response'

--- a/.github/workflows/label_new_issues.yml
+++ b/.github/workflows/label_new_issues.yml
@@ -12,3 +12,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: 'needs response'
+          

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: Close Stale Issues
+on:
+  schedule:
+    - cron: '30 8 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been automatically marked as stale due to inactivity and will be closed in 7 days if no further activity occurs.'
+          close-issue-message: 'This issue was closed due to inactivity. Please reopen if you still encounter this problem or have more information to add.'
+          days-before-stale: 14
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'do not stale, needs response'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,3 +16,4 @@ jobs:
           days-before-close: 7
           stale-issue-label: 'stale'
           exempt-issue-labels: 'do not stale, needs response'
+          


### PR DESCRIPTION
Added new issue labeler which labels new issues with 'needs response'
Added Stalebot which ignores 'needs response' and 'do not stale'

Tested in a fork of the Python library with and without 'needs response' label
