### PR TITLE
feat: add support for terminal region

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -85,7 +85,7 @@ module Adyen
           url = "https://management-#{@env}.adyen.com"
           supports_live_url_prefix = false
         when 'TerminalCloudAPI'
-          url = if terminal_region.present?
+          url = if !terminal_region.nil?
             "https://terminal-api-#{@env}-#{terminal_region}.adyen.com"
           else
             "https://terminal-api-#{@env}.adyen.com"

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -13,10 +13,10 @@ require_relative './result'
 module Adyen
   class Client
     attr_accessor :ws_user, :ws_password, :api_key, :oauth_token, :client, :adapter
-    attr_reader :env, :connection_options, :adapter_options
+    attr_reader :env, :connection_options, :adapter_options, :terminal_region
 
     def initialize(ws_user: nil, ws_password: nil, api_key: nil, oauth_token: nil, env: :live, adapter: nil, mock_port: 3001,
-                   live_url_prefix: nil, mock_service_url_base: nil, connection_options: nil, adapter_options: nil)
+                   live_url_prefix: nil, mock_service_url_base: nil, connection_options: nil, adapter_options: nil, terminal_region: nil)
       @ws_user = ws_user
       @ws_password = ws_password
       @api_key = api_key
@@ -33,6 +33,7 @@ module Adyen
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       @live_url_prefix = live_url_prefix
       @connection_options = connection_options || Faraday::ConnectionOptions.new
+      @terminal_region = terminal_region
     end
 
     # make sure that env can only be :live, :test, or :mock
@@ -84,7 +85,11 @@ module Adyen
           url = "https://management-#{@env}.adyen.com"
           supports_live_url_prefix = false
         when 'TerminalCloudAPI'
-          url = "https://terminal-api-#{@env}.adyen.com"
+          url = if terminal_region.present?
+            "https://terminal-api-#{@env}-#{terminal_region}.adyen.com"
+          else
+            "https://terminal-api-#{@env}.adyen.com"
+          end
           supports_live_url_prefix = false
         else
           raise ArgumentError, 'Invalid service specified'


### PR DESCRIPTION
**Description**
- feat: added support for terminal cloud API endpoints that are regional

**Tested scenarios**
- By default terminal region is nil
- If terminal region is supplied we will suffix the api endpoint with the region.

**Fixed issue**:  
#255