### PR TITLE
added unit-test for terminal_region

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -260,4 +260,16 @@ RSpec.describe Adyen do
       .to eq('https://terminal-api-test.adyen.com/connectedTerminals')
 
   end
+          
+  it 'checks the initialization of the terminal region' do
+    client = Adyen::Client.new(api_key: 'api_key', env: :test, terminal_region: 'eu')
+    expect(client.service_url('TerminalCloudAPI', 'connectedTerminals', nil))
+    .to eq('https://terminal-api-test-eu.adyen.com/connectedTerminals')
+  end
+
+  it 'checks the initialization of the terminal region set to nil per default' do
+    client = Adyen::Client.new(api_key: 'api_key', env: :test)
+    expect(client.service_url('TerminalCloudAPI', 'connectedTerminals', nil))
+    .to eq('https://terminal-api-test.adyen.com/connectedTerminals')
+  end
 end


### PR DESCRIPTION
Recently the terminal_region attribute was added to Client.rb to append the regional suffix to the base url if initialized. [link to pr](https://github.com/Adyen/adyen-ruby-api-library/pull/256)

- Added test to check if terminal_region was added to the base-url.
- Added test to check absence of region suffix if terminal region was not initialized.

Tested the client_spec.rb file and all tests passed.