### PR TITLE
Factory method for PosMobile service

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -287,6 +287,10 @@ module Adyen
       @terminal_cloud_api ||= Adyen::TerminalCloudAPI.new(self)
     end
 
+    def pos_mobile
+      @pos_mobile ||= Adyen::PosMobile.new(self)
+    end
+
     private
 
     def auth_header(auth_type, faraday)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -272,4 +272,10 @@ RSpec.describe Adyen do
     expect(client.service_url('TerminalCloudAPI', 'connectedTerminals', nil))
     .to eq('https://terminal-api-test.adyen.com/connectedTerminals')
   end
+
+  it 'checks the creation of PosMobile sessions url' do
+    client = Adyen::Client.new(api_key: 'api_key', env: :test)
+    expect(client.service_url('PosMobile', 'sessions', nil))
+      .to eq('https://checkout-test.adyen.com/checkout/possdk/sessions')
+  end
 end


### PR DESCRIPTION
**Description**

There's a PosMobile service available in the library, but it must be initialized manually, which is not consistent with the way other services can be accessed through the Client class.

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
