### PR TITLE
Update DisputesService in Client

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -53,6 +53,7 @@ module Adyen
 
     # base URL for API given service and @env
     def service_url_base(service)
+      service = 'DisputesService' if service == 'Disputes'
       if @env == :mock
         @mock_service_url_base
       else

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -53,6 +53,7 @@ module Adyen
 
     # base URL for API given service and @env
     def service_url_base(service)
+      # maps 'Disputes' to expected service name 'DisputesService' for URL matching
       service = 'DisputesService' if service == 'Disputes'
       if @env == :mock
         @mock_service_url_base

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -278,4 +278,10 @@ RSpec.describe Adyen do
     expect(client.service_url('PosMobile', 'sessions', nil))
       .to eq('https://checkout-test.adyen.com/checkout/possdk/sessions')
   end
+
+  it 'correctly maps Disputes to DisputesService and generates valid URL' do
+    client = Adyen::Client.new(env: :test)
+    expect(client.service_url_base('Disputes'))
+      .to eq('https://ca-test.adyen.com/ca/services/DisputesService')
+  end  
 end


### PR DESCRIPTION
Using Disputes API caused `Invalid service specified` error. 
- This fix maps `Disputes` to `DisputesService` in the client so URL builds correctly
- Added Unit test to check if valid URL is generated
