### PR TITLE
Add Timeout Settings to Client

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -32,7 +32,12 @@ module Adyen
       end
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       @live_url_prefix = live_url_prefix
-      @connection_options = connection_options || Faraday::ConnectionOptions.new
+      @connection_options = connection_options || Faraday::ConnectionOptions.new (
+          request: {
+          open_timeout: 5,  # seconds to establish connection
+          timeout: 10       # seconds to wait for response
+        }
+      )
       @terminal_region = terminal_region
     end
 

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -47,7 +47,12 @@ module Adyen
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       @live_url_prefix = live_url_prefix
       # Use connection_options if provided, otherwise global Adyen.configuration options
-      @connection_options = Faraday::ConnectionOptions.new(connection_options || Adyen.configuration.connection_options)
+      @connection_options = 
+        if connection_options.is_a?(Faraday::ConnectionOptions)
+          connection_options
+        else
+          Faraday::ConnectionOptions.new(connection_options || Adyen.configuration.connection_options)
+        end
       @terminal_region = terminal_region
     end
 

--- a/lib/adyen/configuration.rb
+++ b/lib/adyen/configuration.rb
@@ -1,0 +1,34 @@
+module Adyen
+    class Configuration
+        attr_accessor :connection_options
+        
+        def initialize
+            set_defaults
+        end
+
+        def set_defaults
+            @connection_options = {
+                request: {
+                timeout: 60,        # default total request timeout
+                open_timeout: 30,   # default connection timeout
+                read_timeout: 30,   # default read timeout
+                write_timeout: 30   # default write timeout
+            }
+        }
+        end
+
+        # method to override or merge options
+        def update_connection_options(new_options)
+            @connection_options = deep_merge(@connection_options, new_options)
+        end
+
+        private
+
+        # deep merge helper
+        def deep_merge(hash1, hash2)
+            hash1.merge(hash2) do |key, oldval, newval|
+                oldval.is_a?(Hash) && newval.is_a?(Hash) ? deep_merge(oldval, newval) : newval
+            end
+        end
+    end
+end

--- a/lib/adyen/configuration.rb
+++ b/lib/adyen/configuration.rb
@@ -1,34 +1,23 @@
 module Adyen
-    class Configuration
-        attr_accessor :connection_options
-        
-        def initialize
-            set_defaults
-        end
+  class Configuration
+    attr_accessor :connection_options
 
-        def set_defaults
-            @connection_options = {
-                request: {
-                timeout: 60,        # default total request timeout
-                open_timeout: 30,   # default connection timeout
-                read_timeout: 30,   # default read timeout
-                write_timeout: 30   # default write timeout
-            }
-        }
-        end
-
-        # method to override or merge options
-        def update_connection_options(new_options)
-            @connection_options = deep_merge(@connection_options, new_options)
-        end
-
-        private
-
-        # deep merge helper
-        def deep_merge(hash1, hash2)
-            hash1.merge(hash2) do |key, oldval, newval|
-                oldval.is_a?(Hash) && newval.is_a?(Hash) ? deep_merge(oldval, newval) : newval
-            end
-        end
+    def initialize
+      set_defaults
     end
+
+    def set_defaults
+      @connection_options = {
+        timeout: 60,        # total request timeout in seconds
+        open_timeout: 30,   # time to establish a connection
+        read_timeout: 30,   # time to wait for a response
+        write_timeout: 30   # time to send data
+      }
+    end
+
+    # Allow updating timeout options
+    def update_connection_options(new_options)
+      @connection_options.merge!(new_options)
+    end
+  end
 end


### PR DESCRIPTION
* Added a Configuration class (configuration.rb) to manage connection timeout settings.
* Defined default timeout values for requests:
          timeout: 60,
          open_timeout: 30,
          read_timeout: 30,
          write_timeout: 30.
* Exposed Adyen.configuration and Adyen.configure methods for setting global configuration options.
* Updated Client to use Adyen.configuration.connection_options if no connection_options are passed during initialization.
