### PR TITLE
Support Adyen::Client.new(logger: Logger.new($stdout))

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -12,11 +12,12 @@ require_relative './result'
 
 module Adyen
   class Client
-    attr_accessor :ws_user, :ws_password, :api_key, :oauth_token, :client, :adapter
+    attr_accessor :ws_user, :ws_password, :api_key, :oauth_token, :client, :adapter, :logger
     attr_reader :env, :connection_options, :adapter_options, :terminal_region
 
     def initialize(ws_user: nil, ws_password: nil, api_key: nil, oauth_token: nil, env: :live, adapter: nil, mock_port: 3001,
-                   live_url_prefix: nil, mock_service_url_base: nil, connection_options: nil, adapter_options: nil, terminal_region: nil)
+                   logger: nil, live_url_prefix: nil, mock_service_url_base: nil, connection_options: nil, adapter_options: nil,
+                   terminal_region: nil)
       @ws_user = ws_user
       @ws_password = ws_password
       @api_key = api_key
@@ -32,6 +33,7 @@ module Adyen
       end
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       @live_url_prefix = live_url_prefix
+      @logger = logger
       if RUBY_VERSION >= '3.2'
         # set default timeouts
         @connection_options = connection_options || Faraday::ConnectionOptions.new(
@@ -162,6 +164,10 @@ module Adyen
         # add library headers
         faraday.headers['adyen-library-name'] = Adyen::NAME
         faraday.headers['adyen-library-version'] = Adyen::VERSION
+
+        if @logger
+          faraday.response :logger, @logger, bodies: true
+        end
       end
       # if json string convert to hash
       # needed to add applicationInfo

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -166,6 +166,7 @@ module Adyen
         faraday.headers['adyen-library-version'] = Adyen::VERSION
 
         if @logger
+          # Configures Faraday's response logger middleware to log HTTP requests and responses when a logger is provided.
           faraday.response :logger, @logger
         end
       end

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -166,7 +166,7 @@ module Adyen
         faraday.headers['adyen-library-version'] = Adyen::VERSION
 
         if @logger
-          faraday.response :logger, @logger, bodies: true
+          faraday.response :logger, @logger
         end
       end
       # if json string convert to hash


### PR DESCRIPTION
`Faraday` supports logging of responses but annoyingly this can only be configured at the time of constructing the `Faraday.new` instance, and `Adyen::Client` locks this initialization inside `call_adyen_api` method.

This PR adds new `logger:` argument and `#logger=` setter to `Adyen::Client`.

Example usage:

```ruby
client = Adyen::Client.new
client.logger = Logger.new($stdout)
```

or 

```ruby
client = Adyen::Client.new(logger: Logger.new($stdout))
```

Output in logs might look like:

```
I, [2025-07-21T06:20:24.131342 #45006]  INFO -- : request: POST https://checkout-test.adyen.com/v71/payments
I, [2025-07-21T06:20:24.131376 #45006]  INFO -- : request: Content-Type: "application/json"
User-Agent: "adyen-ruby-api-library/10.3.0"
x-api-key: "l123AQEuhmfxL4..."
adyen-library-name: "adyen-ruby-api-library"
adyen-library-version: "10.3.0"
I, [2025-07-21T06:20:24.131403 #45006]  INFO -- : request: {"reference":"xyz","paymentMethod":{"type":"scheme","checkoutAttemptId":"0849f4a5","encryptedCardNumber":"eyJhbGciOi...
I, [2025-07-21T06:20:25.564473 #45006]  INFO -- : response: Status 200
I, [2025-07-21T06:20:25.564604 #45006]  INFO -- : response: traceparent: "00-
...
transfer-encoding: "chunked"
date: "Mon, 21 Jul 2025 06:20:25 GMT"
strict-transport-security: "max-age=31536000; includeSubDomains"
I, [2025-07-21T06:20:25.564697 #45006]  INFO -- : response: {"additionalData":{"cardSummary":"0008","isCardCommercial":"unknown","authorisationMid":"50","...
```