### PR TITLE
Release Workflow: run only for PRs from maintainers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   release:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
The Release workflow fails when it is triggered by an external PR because the GitHub token `ADYEN_AUTOMATION_BOT_ACCESS_TOKEN` cannot be injected during the execution of the GitHub action.

This PR introduces a check to confirm the PR was opened from the same repository (not from an external fork).