### PR TITLE
Improve error handling

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -215,6 +215,8 @@ module Adyen
       end
       # check for API errors
       case response.status
+      when 400
+        raise Adyen::FormatError.new('Invalid format or fields', request_data, response.body)
       when 401
         raise Adyen::AuthenticationError.new(
           'Invalid API authentication; https://docs.adyen.com/user-management/how-to-get-the-api-key', request_data
@@ -222,6 +224,10 @@ module Adyen
       when 403
         raise Adyen::PermissionError.new('Missing user permissions; https://docs.adyen.com/user-management/user-roles',
                                          request_data, response.body)
+      when 422
+        raise Adyen::ValidationError.new('Validation error', request_data, response.body)
+      when 500..599
+        raise Adyen::ServerError.new('Internal server error', request_data, response.body)
       end
 
       # delete has no response.body (unless it throws an error)

--- a/lib/adyen/errors.rb
+++ b/lib/adyen/errors.rb
@@ -79,7 +79,15 @@ module Adyen
     end
   end
 
+  # when JSON payload is invalid
   class FormatError < AdyenError
+    def initialize(msg, request, response)
+      super(request, response, msg, 400)
+    end
+  end
+
+  # when JSON payload cannot be processed (violates business rules)
+  class ValidationError < AdyenError
     def initialize(msg, request, response)
       super(request, response, msg, 422)
     end
@@ -94,12 +102,6 @@ module Adyen
   class ConfigurationError < AdyenError
     def initialize(msg, request)
       super(request, nil, msg, 905)
-    end
-  end
-
-  class ValidationError < AdyenError
-    def initialize(msg, request)
-      super(request, nil, msg, nil)
     end
   end
 


### PR DESCRIPTION
When a validation error `422` is returned by the API
```
{
  "type": "https://docs.adyen.com/errors/validation",
  "title": "The request is missing required fields or contains invalid data.",
  "status": 422,
  "detail": "It is mandatory to specify a legalEntityId when creating a new account holder.",
  "invalidFields": [{"name": "legalEntityId", "message": "legalEntityId is not provided"}],
  "errorCode": "30_011"
}
```
the library doesn't raise an error, but it returns instead `AdyenResult`: it is then responsibility of the code calling the client to inspect the `AdyenResult` object and understand the type of error.

This PR updates the logic in `client.rb` to convert `400`, `422` and `500` responses in the corresponding error.
