### PR TITLE
 Introduce `Client#call_adyen_api_url` method that accepts a full URL and HTTP method instead of relying on `service` & `action` parameters

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -145,9 +145,7 @@ module Adyen
       # get URL for requested endpoint
       url = service_url(service, action.is_a?(String) ? action : action.fetch(:url), version)
 
-      # make sure valid authentication has been provided
-      validate_auth_type(service, request_data)
-
+      # get method from action or default to post
       method = action.is_a?(String) ? 'post' : action.fetch(:method)
 
       call_adyen_api_url(url, method, request_data, headers)
@@ -156,7 +154,7 @@ module Adyen
     # send request to adyen API with a given full URL
     def call_adyen_api_url(url, method, request_data, headers)
       # make sure valid authentication has been provided, without a specific service
-      validate_auth_type(nil, request_data)
+      validate_auth(request_data)
 
       # initialize Faraday connection object
       conn = Faraday.new(url, @connection_options) do |faraday|
@@ -343,17 +341,13 @@ module Adyen
       "basic"
     end
 
-    def validate_auth_type(service, request_data)
+    def validate_auth(request_data)
       # ensure authentication has been provided
       if @api_key.nil? && @oauth_token.nil? && (@ws_password.nil? || @ws_user.nil?)
         raise Adyen::AuthenticationError.new(
           'No authentication found - please set api_key, oauth_token, or ws_user and ws_password',
           request_data
         )
-      end
-      if service == "PaymentSetupAndVerification" && @api_key.nil? && @oauth_token.nil? && @ws_password.nil? && @ws_user.nil?
-        raise Adyen::AuthenticationError.new('Checkout service requires API-key or oauth_token', request_data),
-              'Checkout service requires API-key or oauth_token'
       end
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -556,6 +556,14 @@ RSpec.describe Adyen do
 
       expect(request_body_sent).to eq(hash_data.to_json)
     end
+
+    it 'validates authentication is provided' do
+      client_without_auth = Adyen::Client.new(env: :test)
+
+      expect {
+        client_without_auth.call_adyen_api('Checkout', 'payments', {}, {}, '71')
+      }.to raise_error(Adyen::AuthenticationError, /No authentication found/)
+    end
   end
 
   describe '#call_adyen_api_url' do


### PR DESCRIPTION
**Description**

This introduces the `Client#call_adyen_api_url` method, that can be used to make an API call by specifying a full URL and HTTP method, while still taking care of authentication & basic error handling.

**Tested scenarios**

I added test coverage for both the existing `Client#call_adyen_api` method as this modifies it, and the new `Client#call_adyen_api_url`, I tried to stick to mocking practices uses in the rest of the repository.
