### PR TITLE
feat(capital): Add test coverage and client integration for Capital API

### DIFF
--- a/lib/adyen-ruby-api-library.rb
+++ b/lib/adyen-ruby-api-library.rb
@@ -23,4 +23,5 @@ require_relative 'adyen/services/posMobile'
 require_relative 'adyen/services/openBanking'
 require_relative 'adyen/services/sessionAuthentication'
 require_relative 'adyen/services/balanceControl'
+require_relative 'adyen/services/capital'
 

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -97,6 +97,9 @@ module Adyen
         when 'Transfers'
           url = "https://balanceplatform-api-#{@env}.adyen.com/btl"
           supports_live_url_prefix = false
+        when 'Capital'
+          url = "https://balanceplatform-api-#{@env}.adyen.com/capital"
+          supports_live_url_prefix = false
         when 'Management'
           url = "https://management-#{@env}.adyen.com"
           supports_live_url_prefix = false
@@ -329,6 +332,10 @@ module Adyen
 
     def balance_control
       @balance_control ||= Adyen::BalanceControl.new(self)
+    end
+
+    def capital
+      @capital ||= Adyen::Capital.new(self)
     end
 
   

--- a/spec/capital_spec.rb
+++ b/spec/capital_spec.rb
@@ -1,0 +1,186 @@
+require 'spec_helper'
+require 'json'
+
+RSpec.describe Adyen::Capital do
+  let(:client) { create_client(:api_key) }
+  let(:service) { 'Capital' }
+  let(:version) { client.capital.version }
+
+  describe 'GrantAccountsApi' do
+    it 'gets grant account information' do
+      response_body = json_from_file('mocks/responses/Capital/get-grant-account-success.json')
+      grant_account_id = 'CG00000000000000000000001'
+
+      url = client.service_url(service, "grantAccounts/#{grant_account_id}", version)
+
+      WebMock.stub_request(:get, url)
+             .with(headers: { 'x-api-key' => client.api_key })
+             .to_return(body: response_body)
+
+      result = client.capital.grant_accounts_api.get_grant_account_information(grant_account_id)
+
+      expect(result.status).to eq(200)
+      expect(result.response).to eq(JSON.parse(response_body))
+      expect(result.response).to be_a(Adyen::HashWithAccessors)
+      expect(result.response).to be_a(Hash)
+    end
+  end
+
+  describe 'GrantOffersApi' do
+    it 'gets all grant offers with query params' do
+      response_body = json_from_file('mocks/responses/Capital/grant-offers-success.json')
+      account_holder_id = 'AH00000000000000000000001'
+
+      url = client.service_url(service, 'grantOffers', version)
+
+      WebMock.stub_request(:get, url)
+             .with(
+               query: { 'accountHolderId' => account_holder_id },
+               headers: { 'x-api-key' => client.api_key }
+             )
+             .to_return(body: response_body)
+
+      result = client.capital.grant_offers_api.get_all_grant_offers(query_params: { 'accountHolderId' => account_holder_id })
+
+      expect(result.status).to eq(200)
+      expect(result.response).to eq(JSON.parse(response_body))
+    end
+
+    it 'gets all grant offers without query params' do
+      response_body = json_from_file('mocks/responses/Capital/grant-offers-success.json')
+
+      url = client.service_url(service, 'grantOffers', version)
+
+      WebMock.stub_request(:get, url)
+             .with(headers: { 'x-api-key' => client.api_key })
+             .to_return(body: response_body)
+
+      result = client.capital.grant_offers_api.get_all_grant_offers
+
+      expect(result.status).to eq(200)
+      expect(result.response).to eq(JSON.parse(response_body))
+    end
+
+    it 'gets a specific grant offer' do
+      response_body = json_from_file('mocks/responses/Capital/get-grant-offer-success.json')
+      id = 'GO00000000000000000000001'
+
+      url = client.service_url(service, "grantOffers/#{id}", version)
+
+      WebMock.stub_request(:get, url)
+             .with(headers: { 'x-api-key' => client.api_key })
+             .to_return(body: response_body)
+
+      result = client.capital.grant_offers_api.get_grant_offer(id)
+
+      expect(result.status).to eq(200)
+      expect(result.response).to eq(JSON.parse(response_body))
+    end
+  end
+
+  describe 'GrantsApi' do
+    it 'gets a specific grant' do
+      response_body = json_from_file('mocks/responses/Capital/get-grant-success.json')
+      id = 'GR00000000000000000000001'
+
+      url = client.service_url(service, "grants/#{id}", version)
+
+      WebMock.stub_request(:get, url)
+             .with(headers: { 'x-api-key' => client.api_key })
+             .to_return(body: response_body)
+
+      result = client.capital.grants_api.get_grant(id)
+
+      expect(result.status).to eq(200)
+      expect(result.response).to eq(JSON.parse(response_body))
+    end
+
+    it 'gets all grants' do
+      response_body = json_from_file('mocks/responses/Capital/grants-success.json')
+
+      url = client.service_url(service, 'grants', version)
+
+      WebMock.stub_request(:get, url)
+             .with(headers: { 'x-api-key' => client.api_key })
+             .to_return(body: response_body)
+
+      result = client.capital.grants_api.get_all_grants
+
+      expect(result.status).to eq(200)
+      expect(result.response).to eq(JSON.parse(response_body))
+    end
+
+    it 'requests a grant' do
+      request_payload = { "grantAccountId" => "GR00000000000000000000001" }
+      response_body = json_from_file('mocks/responses/Capital/request-grant.json')
+
+      url = client.service_url(service, 'grants', version)
+
+      WebMock.stub_request(:post, url)
+             .with(
+               body: request_payload,
+               headers: { 'x-api-key' => client.api_key }
+             )
+             .to_return(body: response_body)
+
+      result = client.capital.grants_api.request_grant(request_payload)
+
+      expect(result.status).to eq(200)
+      expect(result.response).to eq(JSON.parse(response_body))
+    end
+
+    it 'gets a grant disbursement' do
+      response_body = json_from_file('mocks/responses/Capital/get-grant-disbursement-success.json')
+      grant_id = 'GR00000000000000000000001'
+      disbursement_id = 'DI00000000000000000000001'
+
+      url = client.service_url(service, "grants/#{grant_id}/disbursements/#{disbursement_id}", version)
+
+      WebMock.stub_request(:get, url)
+             .with(headers: { 'x-api-key' => client.api_key })
+             .to_return(body: response_body)
+
+      result = client.capital.grants_api.get_grant_disbursement(grant_id, disbursement_id)
+
+      expect(result.status).to eq(200)
+      expect(result.response).to eq(JSON.parse(response_body))
+    end
+
+    it 'gets all grant disbursements' do
+      response_body = json_from_file('mocks/responses/Capital/get-grant-disbursements-success.json')
+      grant_id = 'GR00000000000000000000001'
+
+      url = client.service_url(service, "grants/#{grant_id}/disbursements", version)
+
+      WebMock.stub_request(:get, url)
+             .with(headers: { 'x-api-key' => client.api_key })
+             .to_return(body: response_body)
+
+      result = client.capital.grants_api.get_all_grant_disbursements(grant_id)
+
+      expect(result.status).to eq(200)
+      expect(result.response).to eq(JSON.parse(response_body))
+    end
+
+    it 'updates a grant disbursement' do
+      response_body = json_from_file('mocks/responses/Capital/update-grant-disbursement-success.json')
+      grant_id = 'GR00000000000000000000001'
+      disbursement_id = 'DI00000000000000000000001'
+      request_payload = {}
+
+      url = client.service_url(service, "grants/#{grant_id}/disbursements/#{disbursement_id}", version)
+
+      WebMock.stub_request(:patch, url)
+             .with(
+               body: request_payload,
+               headers: { 'x-api-key' => client.api_key }
+             )
+             .to_return(body: response_body)
+
+      result = client.capital.grants_api.update_grant_disbursement(request_payload, grant_id, disbursement_id)
+
+      expect(result.status).to eq(200)
+      expect(result.response).to eq(JSON.parse(response_body))
+    end
+  end
+end

--- a/spec/mocks/responses/Capital/get-grant-account-success.json
+++ b/spec/mocks/responses/Capital/get-grant-account-success.json
@@ -1,0 +1,20 @@
+{
+  "id": "CG00000000000000000000001",
+  "fundingBalanceAccountId": "BA00000000000000000000001",
+  "limits": [
+    {
+      "amount": {
+        "currency": "EUR",
+        "value": 100000
+      }
+    }
+  ],
+  "balances": [
+    {
+      "currency": "EUR",
+      "principal": 10000,
+      "fee": 1000,
+      "total": 11000
+    }
+  ]
+}

--- a/spec/mocks/responses/Capital/get-grant-disbursement-success.json
+++ b/spec/mocks/responses/Capital/get-grant-disbursement-success.json
@@ -1,0 +1,26 @@
+{
+  "id": "DI00000000000000000000001",
+  "grantId": "GR00000000000000000000001",
+  "accountHolderId": "AH00000000000000000000001",
+  "balanceAccountId": "BA00000000000000000000001",
+  "amount": {
+    "currency": "EUR",
+    "value": 10000
+  },
+  "fee": {
+    "amount": {
+      "currency": "EUR",
+      "value": 1000
+    }
+  },
+  "balances": {
+    "currency": "EUR",
+    "principal": 10000,
+    "fee": 1000,
+    "total": 11000
+  },
+  "repayment": {
+    "basisPoints": 1000,
+    "updateDescription": "string"
+  }
+}

--- a/spec/mocks/responses/Capital/get-grant-disbursements-success.json
+++ b/spec/mocks/responses/Capital/get-grant-disbursements-success.json
@@ -1,0 +1,30 @@
+{
+  "disbursements": [
+    {
+      "id": "DI00000000000000000000001",
+      "grantId": "GR00000000000000000000001",
+      "accountHolderId": "AH00000000000000000000001",
+      "balanceAccountId": "BA00000000000000000000001",
+      "amount": {
+        "currency": "EUR",
+        "value": 10000
+      },
+      "fee": {
+        "amount": {
+          "currency": "EUR",
+          "value": 1000
+        }
+      },
+      "balances": {
+        "currency": "EUR",
+        "principal": 10000,
+        "fee": 1000,
+        "total": 11000
+      },
+      "repayment": {
+        "basisPoints": 1000,
+        "updateDescription": "string"
+      }
+    }
+  ]
+}

--- a/spec/mocks/responses/Capital/get-grant-offer-success.json
+++ b/spec/mocks/responses/Capital/get-grant-offer-success.json
@@ -1,0 +1,31 @@
+{
+  "id": "GO00000000000000000000001",
+  "accountHolderId": "AH00000000000000000000001",
+  "contractType": "cashAdvance",
+  "amount": {
+    "currency": "EUR",
+    "value": 10000
+  },
+  "fee": {
+    "amount": {
+      "currency": "EUR",
+      "value": 1000
+    },
+    "aprBasisPoints": 1200
+  },
+  "repayment": {
+    "basisPoints": 1000,
+    "term": {
+      "estimatedDays": 180,
+      "maximumDays": 365
+    },
+    "threshold": {
+      "amount": {
+        "currency": "EUR",
+        "value": 1000
+      }
+    }
+  },
+  "startsAt": "2024-01-01T00:00:00Z",
+  "expiresAt": "2024-01-31T23:59:59Z"
+}

--- a/spec/mocks/responses/Capital/get-grant-success.json
+++ b/spec/mocks/responses/Capital/get-grant-success.json
@@ -1,0 +1,22 @@
+{
+  "id": "GR00000000000000000000001",
+  "grantAccountId": "CG00000000000000000000001",
+  "grantOfferId": "GO00000000000000000000001",
+  "counterparty": {
+    "accountHolderId": "AH00000000000000000000001",
+    "balanceAccountId": "BA00000000000000000000001"
+  },
+  "amount": {
+    "currency": "EUR",
+    "value": 10000
+  },
+  "balances": {
+    "currency": "EUR",
+    "principal": 10000,
+    "fee": 1000,
+    "total": 11000
+  },
+  "status": {
+    "code": "Active"
+  }
+}

--- a/spec/mocks/responses/Capital/grant-offers-success.json
+++ b/spec/mocks/responses/Capital/grant-offers-success.json
@@ -1,0 +1,19 @@
+{
+  "grantOffers": [
+    {
+      "id": "GO00000000000000000000001",
+      "amount": {
+        "currency": "EUR",
+        "value": 10000
+      },
+      "fee": {
+        "currency": "EUR",
+        "value": 100
+      },
+      "repayment": {
+        "currency": "EUR",
+        "value": 10100
+      }
+    }
+  ]
+}

--- a/spec/mocks/responses/Capital/grants-success.json
+++ b/spec/mocks/responses/Capital/grants-success.json
@@ -1,0 +1,26 @@
+{
+  "grants": [
+    {
+      "id": "GR00000000000000000000001",
+      "grantAccountId": "CG00000000000000000000001",
+      "grantOfferId": "GO00000000000000000000001",
+      "counterparty": {
+        "accountHolderId": "AH00000000000000000000001",
+        "balanceAccountId": "BA00000000000000000000001"
+      },
+      "amount": {
+        "currency": "EUR",
+        "value": 10000
+      },
+      "balances": {
+        "currency": "EUR",
+        "principal": 10000,
+        "fee": 1000,
+        "total": 11000
+      },
+      "status": {
+        "code": "Active"
+      }
+    }
+  ]
+}

--- a/spec/mocks/responses/Capital/request-grant.json
+++ b/spec/mocks/responses/Capital/request-grant.json
@@ -1,0 +1,31 @@
+{
+  "id": "GR00000000000000000000001",
+  "grantAccountId": "CG00000000000000000000001",
+  "grantOfferId": "0000000000000001",
+  "counterparty": {
+    "accountHolderId": "AH00000000000000000000001",
+    "balanceAccountId": "BA00000000000000000000001"
+  },
+  "amount": {
+    "currency": "EUR",
+    "value": 1000000
+  },
+  "fee": {
+    "amount": {
+      "value": 120000,
+      "currency": "EUR"
+    }
+  },
+  "balances": {
+    "currency": "EUR",
+    "fee": 120000,
+    "principal": 1000000,
+    "total": 1120000
+  },
+  "repayment": {
+    "basisPoints": 1400
+  },
+  "status": {
+    "code": "Pending"
+  }
+}

--- a/spec/mocks/responses/Capital/update-grant-disbursement-success.json
+++ b/spec/mocks/responses/Capital/update-grant-disbursement-success.json
@@ -1,0 +1,26 @@
+{
+  "id": "DI00000000000000000000001",
+  "grantId": "GR00000000000000000000001",
+  "accountHolderId": "AH00000000000000000000001",
+  "balanceAccountId": "BA00000000000000000000001",
+  "amount": {
+    "currency": "EUR",
+    "value": 10000
+  },
+  "fee": {
+    "amount": {
+      "currency": "EUR",
+      "value": 1000
+    }
+  },
+  "balances": {
+    "currency": "EUR",
+    "principal": 10000,
+    "fee": 1000,
+    "total": 11000
+  },
+  "repayment": {
+    "basisPoints": 1500,
+    "updateDescription": "string"
+  }
+}


### PR DESCRIPTION
**Description**

Added comprehensive RSpec test suite for `Adyen::Capital` services (`GrantAccountsApi`, `GrantOffersApi`, `GrantsApi`).
Integrated the Capital API into the main client by:
- Exposing `Adyen::Capital` via the `client.capital` accessor.
- Configuring the service URL (`balanceplatform-api`) in `Adyen::Client#service_url_base`.
- Requiring the `adyen/services/capital` module in `adyen-ruby-api-library.rb`.

**Tested scenarios**

Created necessary JSON mock response fixtures under `spec/mocks/responses/Capital` to facilitate isolated testing. Tests cover all primary API endpoints for retrieving grant accounts, offers, and grants, as well as making grant requests and managing disbursements, ensuring functionality and correct integration.


**Fixed issue**:  <!-- #-prefixed issue number -->
- N/A