### PR TITLE
GitHub Actions: add  merge_group

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,14 @@
 name: ruby
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:    
+  workflow_dispatch: {}
 
 jobs:
   test:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for Ruby to better control when the workflow runs. The main change is restricting workflow triggers to only the `main` branch and enabling additional manual and merge group triggers.

This is necessary to trigger the GitHub Actions workflow when a pull request is added to a merge queue.

See GitHub [doc](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) 
