### PR TITLE
Use secure_compare for hmac (for Ruby 3+)

### DIFF
--- a/lib/adyen/utils/hmac_validator.rb
+++ b/lib/adyen/utils/hmac_validator.rb
@@ -29,7 +29,7 @@ module Adyen
         merchant_sign =
           webhook_request_item.dig('additionalData', 'hmacSignature')
 
-        expected_sign == merchant_sign
+        OpenSSL.secure_compare(expected_sign, merchant_sign)
       end
 
       # validates the HMAC signature of a payload against an expected signature. Use for webhooks that provide the
@@ -42,7 +42,7 @@ module Adyen
       # @return [Boolean] Returns true if the HMAC signature is valid, otherwise false.
       def valid_webhook_payload_hmac?(hmac_signature, hmac_key, payload)
         expected_sign = calculate_webhook_payload_hmac(payload, hmac_key)
-        expected_sign == hmac_signature
+        OpenSSL.secure_compare(expected_sign, hmac_signature)
       end
 
       # <b>DEPRECATED:</b> Please use calculate_webhook_hmac() instead.

--- a/lib/adyen/utils/hmac_validator.rb
+++ b/lib/adyen/utils/hmac_validator.rb
@@ -29,7 +29,7 @@ module Adyen
         merchant_sign =
           webhook_request_item.dig('additionalData', 'hmacSignature')
 
-        OpenSSL.secure_compare(expected_sign, merchant_sign)
+        merchant_sign.is_a?(String) && OpenSSL.secure_compare(expected_sign, merchant_sign)
       end
 
       # validates the HMAC signature of a payload against an expected signature. Use for webhooks that provide the
@@ -42,7 +42,7 @@ module Adyen
       # @return [Boolean] Returns true if the HMAC signature is valid, otherwise false.
       def valid_webhook_payload_hmac?(hmac_signature, hmac_key, payload)
         expected_sign = calculate_webhook_payload_hmac(payload, hmac_key)
-        OpenSSL.secure_compare(expected_sign, hmac_signature)
+        hmac_signature.is_a?(String) && OpenSSL.secure_compare(expected_sign, hmac_signature)
       end
 
       # <b>DEPRECATED:</b> Please use calculate_webhook_hmac() instead.

--- a/spec/utils/hmac_validator_spec.rb
+++ b/spec/utils/hmac_validator_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe Adyen::Utils::HmacValidator do
       expect(validator.valid_webhook_payload_hmac?(hmac_signature, key, payload)).to be true
     end
 
+    it 'returns false when additionalData hmacSignature is nil' do
+      webhook_request_item['additionalData'] = { 'hmacSignature' => nil }
+
+      expect(validator.valid_webhook_hmac?(webhook_request_item, key)).to be false
+    end
+
+    it 'returns false when payload webhook hmac_signature is nil' do
+      payload = json_from_file('mocks/responses/Webhooks/mixed_webhook.json')
+
+      expect(validator.valid_webhook_payload_hmac?(nil, key, payload)).to be false
+    end
+
   end
 
   describe 'consumer-side regression' do


### PR DESCRIPTION
Uses the OpenSSL secure_compare to prevent timing attacks against the hmac signature

**Description**
While implementing webhooks, I noticed the Ruby library did not use a secure_compare operation to validate the HMAC. This makes a [timing attack](https://en.wikipedia.org/wiki/Timing_attack) possible where an attacker could measure how long the response took to deduce how many bytes of the hmac they got correct. 

This is an admittedly difficult flaw to exploit on its own - forging webhooks would require a very motivated attacker to discover a user's adyen endpoints, breach the username and password, and create a plausible webhook for a transaction, before finally brute forcing the endpoint with different signatures. Since you don't recommend validating in the initial receipt of the webhook, it would be difficult for the attacker to get _any_ feedback on timing. 

**Tested scenarios**
I validated that spec/utils/hmac_validator_spec.rb still passes, which should be a good indicator that hmac validation continues to work. There doesn't appear to be a good way to create a test that validates there's not a timing attack, so I did not add any new tests. 