### PR TITLE
Fix create_query_string appending trailing '?' when query_params is empty

### DIFF
--- a/lib/adyen/services/service.rb
+++ b/lib/adyen/services/service.rb
@@ -27,8 +27,9 @@ module Adyen
     end
 
     # create query parameter from a hash
-    def create_query_string(arr)
-      "?#{URI.encode_www_form(arr)}"
+    def create_query_string(params)
+      return '' if params.empty?
+      "?#{URI.encode_www_form(params)}"
     end
   end
 end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe Adyen::Service do
       expect(described_class.action_for_method_name(:get_onboarding_url)).to eq 'getOnboardingUrl'
     end
   end
+
+  describe '#create_query_string' do
+    let(:service) { described_class.new(double('client'), 'v1', 'TestService') }
+
+    it 'returns empty string when params are empty' do
+      expect(service.create_query_string({})).to eq ''
+    end
+
+    it 'returns query string with ? prefix when params are present' do
+      expect(service.create_query_string({ key: 'value' })).to eq '?key=value'
+    end
+
+    it 'encodes multiple params' do
+      expect(service.create_query_string({ a: '1', b: '2' })).to eq '?a=1&b=2'
+    end
+  end
 end
 # rubocop:enable Layout/LineLength
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## Context

Fixes #362.

The `create_query_string` method was always prepending `?` to the encoded parameters, even when the `query_params` hash was empty, resulting in malformed URLs like `mandates?`.

## Change

Added an early return guard so `?` is only prepended when there are actual params to encode. Also renamed the parameter from `arr` to `params` for clarity.

## Tests

Added unit tests for `create_query_string` covering empty params, a single param, and multiple params.