### PR TITLE
[Chore] Extract duplicated endpoint URL building logic into a helper method

### DIFF
--- a/lib/adyen/services/service.rb
+++ b/lib/adyen/services/service.rb
@@ -30,5 +30,12 @@ module Adyen
     def create_query_string(arr)
       "?#{URI.encode_www_form(arr)}"
     end
+
+    private
+
+    def build_endpoint(path, *params)
+      endpoint = path.gsub('%', '%%').gsub(/{.+?}/, '%s').delete_prefix('/')
+      format(endpoint, *params)
+    end
   end
 end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -3,6 +3,30 @@
 require 'spec_helper'
 
 RSpec.describe Adyen::Service do
+  describe '#build_endpoint' do
+    subject(:service) { described_class.new(nil, nil, 'Test') }
+
+    it 'strips the leading slash' do
+      expect(service.send(:build_endpoint, '/accountHolders')).to eq 'accountHolders'
+    end
+
+    it 'substitutes a single path parameter' do
+      expect(service.send(:build_endpoint, '/accountHolders/{id}', 'AH123')).to eq 'accountHolders/AH123'
+    end
+
+    it 'substitutes multiple path parameters' do
+      expect(service.send(:build_endpoint, '/merchants/{merchantId}/stores/{storeId}', 'M1', 'S2')).to eq 'merchants/M1/stores/S2'
+    end
+
+    it 'handles a path with no parameters' do
+      expect(service.send(:build_endpoint, '/companies')).to eq 'companies'
+    end
+
+    it 'preserves literal percent characters in the path' do
+      expect(service.send(:build_endpoint, '/path%20with/{id}/spaces', 'X')).to eq 'path%20with/X/spaces'
+    end
+  end
+
   describe '.action_for_method_name' do
     it 'handles all methods that exist currently' do
       expect(described_class.action_for_method_name(:adjust_authorisation)).to eq 'adjustAuthorisation'

--- a/templates/api-small.mustache
+++ b/templates/api-small.mustache
@@ -20,9 +20,7 @@ module Adyen
     # Deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}}
     # {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}{{/isDeprecated}}
     def {{#lambda.snakecase}}{{#vendorExtensions.x-methodName}}{{.}}{{/vendorExtensions.x-methodName}}{{^vendorExtensions.x-methodName}}{{nickname}}{{/vendorExtensions.x-methodName}}{{/lambda.snakecase}}({{#bodyParams}}request, {{/bodyParams}}{{#requiredParams}}{{^isQueryParam}}{{#lambda.snakecase}}{{paramName}}{{/lambda.snakecase}}, {{/isQueryParam}}{{/requiredParams}}headers: {}{{#queryParams}}{{#-first}}, query_params: {}{{/-first}}{{/queryParams}})
-      endpoint = '{{path}}'.gsub(/{.+?}/, '%s')
-      endpoint = endpoint.gsub(%r{^/}, '')
-      endpoint = format(endpoint{{#pathParams}}{{#lambda.snakecase}}, {{paramName}}{{/lambda.snakecase}}{{/pathParams}})
+      endpoint = build_endpoint('{{path}}'{{#pathParams}}, {{#lambda.snakecase}}{{paramName}}{{/lambda.snakecase}}{{/pathParams}})
       {{#queryParams}}{{#-first}}endpoint += create_query_string(query_params){{/-first}}{{/queryParams}}
       action = { method: '{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}', url: endpoint }
   {{#bodyParams}}        

--- a/templates/api.mustache
+++ b/templates/api.mustache
@@ -19,9 +19,7 @@ module Adyen
     # Deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}}
     # {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}{{/isDeprecated}}
     def {{#lambda.snakecase}}{{#vendorExtensions.x-methodName}}{{.}}{{/vendorExtensions.x-methodName}}{{^vendorExtensions.x-methodName}}{{nickname}}{{/vendorExtensions.x-methodName}}{{/lambda.snakecase}}({{#bodyParams}}request, {{/bodyParams}}{{#pathParams}}{{#lambda.snakecase}}{{paramName}}{{/lambda.snakecase}}, {{/pathParams}}headers: {}{{#queryParams}}{{#-first}}, query_params: {}{{/-first}}{{/queryParams}})
-      endpoint = '{{path}}'.gsub(/{.+?}/, '%s')
-      endpoint = endpoint.gsub(%r{^/}, '')
-      endpoint = format(endpoint{{#pathParams}}, {{#lambda.snakecase}}{{paramName}}{{/lambda.snakecase}}{{/pathParams}})
+      endpoint = build_endpoint('{{path}}'{{#pathParams}}, {{#lambda.snakecase}}{{paramName}}{{/lambda.snakecase}}{{/pathParams}})
       {{#queryParams}}{{#-first}}endpoint += create_query_string(query_params){{/-first}}{{/queryParams}}
       action = { method: '{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}', url: endpoint }
   {{#bodyParams}}        


### PR DESCRIPTION
Closes #361

## Changes

- Added private `build_endpoint(path, *params)` helper to the base `Service` class, consolidating the repeated 3-line URL construction pattern
- Updated `templates/api.mustache` and `templates/api-small.mustache` to emit a `build_endpoint` call instead of the inline pattern
- Added unit tests for `build_endpoint` in `spec/service_spec.rb`

Note: existing generated service files are unchanged and will adopt the new template on next regeneration.