### PR TITLE
chore(ruby): Drop support for Ruby 2.7-3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.7, '3.0', 3.1, 3.2, head]
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '4.0'
+        ruby: [3.3, 3.4, '4.0', head]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '>= 2.7.0'
+ruby '>= 3.3.0'
 
 gem 'faraday', '2.8.1'
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For more information, refer to our [documentation](https://docs.adyen.com/) or t
 ## Prerequisites
 - [Adyen test account](https://docs.adyen.com/get-started-with-adyen)
 - [API key](https://docs.adyen.com/development-resources/api-credentials#generate-api-key). For testing, your API credential needs to have the [API PCI Payments role](https://docs.adyen.com/development-resources/api-credentials#roles).
-- Ruby >= 2.7
+- Ruby >= 3.3
 
 ## Installation
 

--- a/adyen-ruby-api-library.gemspec
+++ b/adyen-ruby-api-library.gemspec
@@ -3,7 +3,7 @@ require_relative 'lib/adyen/version'
 Gem::Specification.new do |spec|
   spec.name = 'adyen-ruby-api-library'
   spec.version = Adyen::VERSION
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.3.0'
   spec.authors = ['Adyen']
   spec.email = ['support@adyen.com']
 

--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -34,18 +34,13 @@ module Adyen
       end
       @mock_service_url_base = mock_service_url_base || "http://localhost:#{mock_port}"
       self.live_url_prefix = live_url_prefix
-      if RUBY_VERSION >= '3.2'
-        # set default timeouts
-        @connection_options = connection_options || Faraday::ConnectionOptions.new(
-          request: Faraday::RequestOptions.new(
-            open_timeout: 30,
-            timeout: 60
-          )
+      # set default timeouts
+      @connection_options = connection_options || Faraday::ConnectionOptions.new(
+        request: Faraday::RequestOptions.new(
+          open_timeout: 30,
+          timeout: 60
         )
-      else
-        @connection_options = connection_options || Faraday::ConnectionOptions.new
-      end
-
+      )
       @terminal_region = terminal_region
     end
 

--- a/lib/adyen/deprecation.rb
+++ b/lib/adyen/deprecation.rb
@@ -1,9 +1,6 @@
 module Adyen
   # Helper module for emitting deprecation warnings for deprecated API methods.
   module Deprecation
-    # `warn` only accepts the `category` keyword on Ruby >= 3.0.
-    CATEGORY_SUPPORT = (RUBY_VERSION.split('.').map(&:to_i) <=> [3, 0]) >= 0
-
     # Set to true to silence all Adyen deprecation warnings, regardless of
     # Warning[:deprecated]. Explicitly setting this attribute (true or false)
     # overrides the ADYEN_SILENCE_DEPRECATIONS environment variable.
@@ -31,13 +28,7 @@ module Adyen
       text = "[DEPRECATED] `#{method_name}` is deprecated"
       text += " since #{since}" if since
       text += ". #{message}" if message
-      if CATEGORY_SUPPORT
-        Kernel.warn(text, category: :deprecated, uplevel: 2)
-      elsif Warning[:deprecated]
-        # Ruby 2.7 exposes the :deprecated flag but cannot emit into the category,
-        # so honour the flag by hand to keep the behaviour consistent.
-        Kernel.warn(text, uplevel: 2)
-      end
+      Kernel.warn(text, category: :deprecated, uplevel: 2)
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -169,9 +169,7 @@ RSpec.describe Adyen do
     Adyen::Client.new(env: :test, connection_options: connection_options)
   end
 
-  # test with Ruby 3.2+ only (where Faraday requestOptions timeout is supported)
   it 'initiates a Faraday connection with the provided options' do
-    skip 'Only runs on Ruby >= 3.2' unless RUBY_VERSION >= '3.2'
     connection_options = Faraday::ConnectionOptions.new(
       request: {
         open_timeout: 5,
@@ -196,9 +194,7 @@ RSpec.describe Adyen do
     client.checkout.payments_api.payments_details(request_body)
   end
 
-  # test with Ruby 3.2+ only (where Faraday requestOptions timeout is supported)
   it 'initiates a Faraday connection with the expected default timeouts' do
-    skip 'Only runs on Ruby >= 3.2' unless RUBY_VERSION >= '3.2'
     client = Adyen::Client.new(env: :test)
     expect(client.connection_options[:request][:open_timeout]).to eq(30)
     expect(client.connection_options[:request][:timeout]).to eq(60)

--- a/spec/deprecation_spec.rb
+++ b/spec/deprecation_spec.rb
@@ -51,8 +51,6 @@ RSpec.describe Adyen::Deprecation do
       end
 
       it 'emits through Warning.warn tagged with the :deprecated category' do
-        skip 'Warning categories require Ruby >= 3.0' unless Adyen::Deprecation::CATEGORY_SUPPORT
-
         Warning[:deprecated] = true
         expect(Warning).to receive(:warn).with(
           /:\d+: warning: \[DEPRECATED\] `foo` is deprecated since Adyen Checkout API v67\n/,
@@ -64,32 +62,6 @@ RSpec.describe Adyen::Deprecation do
 
     context 'when Warning[:deprecated] is false' do
       it 'writes nothing to stderr' do
-        Warning[:deprecated] = false
-        expect { described_class.warn(:foo, since: 'Adyen Checkout API v67') }
-          .not_to output.to_stderr
-      end
-    end
-
-    context 'on Ruby without Warning category support' do
-      before { stub_const('Adyen::Deprecation::CATEGORY_SUPPORT', false) }
-
-      it 'falls back to Kernel#warn when Warning[:deprecated] is true' do
-        Warning[:deprecated] = true
-        expect { described_class.warn(:foo, since: 'Adyen Checkout API v67') }
-          .to output(/\[DEPRECATED\] `foo` is deprecated since Adyen Checkout API v67\n/).to_stderr
-      end
-
-      it 'still emits through Warning.warn, without a category' do
-        Warning[:deprecated] = true
-        # Ruby >= 3.0 passes `category: nil` explicitly; 2.7 passes no kwargs at all
-        expect(Warning).to receive(:warn) do |message, **kwargs|
-          expect(message).to match(/:\d+: warning: \[DEPRECATED\] `foo` is deprecated since Adyen Checkout API v67\n/)
-          expect(kwargs[:category]).to be_nil
-        end
-        described_class.warn(:foo, since: 'Adyen Checkout API v67')
-      end
-
-      it 'writes nothing when Warning[:deprecated] is false' do
         Warning[:deprecated] = false
         expect { described_class.warn(:foo, since: 'Adyen Checkout API v67') }
           .not_to output.to_stderr


### PR DESCRIPTION
Drops support for EOL Ruby versions (2.7 - 3.2) and updates baseline to Ruby 3.3.
