### PR TITLE
Fix: Drop base64 dependency

### DIFF
--- a/lib/adyen/utils/hmac_validator.rb
+++ b/lib/adyen/utils/hmac_validator.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 module Adyen
   module Utils
     class HmacValidator
@@ -51,17 +53,15 @@ module Adyen
       end
 
       def calculate_webhook_payload_hmac(data, hmac_key)
-        Base64.strict_encode64(
-          OpenSSL::HMAC.digest(HMAC_ALGORITHM, [hmac_key].pack('H*'), data)
-        )
+        # Base64 strict encoding
+        [OpenSSL::HMAC.digest(HMAC_ALGORITHM, [hmac_key].pack('H*'), data)].pack('m0')
       end
 
       def calculate_webhook_hmac(webhook_request_item, hmac_key)
         data = data_to_sign(webhook_request_item)
 
-        Base64.strict_encode64(
-          OpenSSL::HMAC.digest(HMAC_ALGORITHM, [hmac_key].pack('H*'), data)
-        )
+        # Base64 strict encoding
+        [OpenSSL::HMAC.digest(HMAC_ALGORITHM, [hmac_key].pack('H*'), data)].pack('m0')
       end
 
       def data_to_sign(webhook_request_item)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 # rubocop:disable Metrics/AbcSize
 
 require 'webmock/rspec'
-require 'base64'
 require_relative '../lib/adyen-ruby-api-library'
 
 # disable external connections
@@ -32,7 +31,8 @@ def create_test(client, service, method_name, parent_object)
   elsif !client.oauth_token.nil?
     headers["Authorization"] = "Bearer #{client.oauth_token}"
   elsif !client.ws_user.nil? && !client.ws_password.nil?
-    auth_header = "Basic #{Base64.encode64("#{client.ws_user}:#{client.ws_password}")}"
+    # Base64 encoding
+    auth_header = "Basic #{["#{client.ws_user}:#{client.ws_password}"].pack('m')}"
     headers['Authorization'] = auth_header.strip
   else
     raise ArgumentError, 'Authentication not set correctly in test case'

--- a/spec/utils/consumer_smoke.rb
+++ b/spec/utils/consumer_smoke.rb
@@ -1,0 +1,23 @@
+# Consumer smoke test for the HMAC validator, run by hmac_validator_spec.rb.
+# Executed in a clean Ruby process that only loads the library.
+# Exits non-zero (via abort) when the library cannot be used standalone.
+
+require 'adyen-ruby-api-library'
+
+validator = Adyen::Utils::HmacValidator.new
+key = '44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056'
+webhook_request_item = {
+  'additionalData' => { 'hmacSignature' => 'coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0=' },
+  'amount' => { 'value' => 1130, 'currency' => 'EUR' },
+  'pspReference' => '7914073381342284',
+  'eventCode' => 'AUTHORISATION',
+  'merchantAccountCode' => 'TestMerchant',
+  'merchantReference' => 'TestPayment-1407325143704',
+  'paymentMethod' => 'visa',
+  'success' => 'true'
+}
+
+abort 'valid_webhook_hmac? returned false' unless validator.valid_webhook_hmac?(webhook_request_item, key)
+
+payload_sign = validator.calculate_webhook_payload_hmac('payload', key)
+abort "unexpected payload hmac: #{payload_sign}" unless payload_sign == 'McjT0WKyyQ5Zqv3FC9sVNf14NYfSAZa1chxoXY3yIlE='

--- a/spec/utils/hmac_validator_spec.rb
+++ b/spec/utils/hmac_validator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'open3'
 
 RSpec.describe Adyen::Utils::HmacValidator do
   let(:validator) { described_class.new }
@@ -77,6 +78,20 @@ RSpec.describe Adyen::Utils::HmacValidator do
       expect(validator.valid_webhook_payload_hmac?(hmac_signature, key, payload)).to be true
     end
 
+  end
+
+  describe 'consumer-side regression' do
+    # Run the validator in a clean Ruby process that only loads the library, like
+    # a consumer application, so test dependencies cannot mask missing dependencies.
+    it 'computes HMAC signatures in a clean consumer process' do
+      lib_dir = File.expand_path('../../lib', __dir__)
+      smoke_test = File.expand_path('consumer_smoke.rb', __dir__)
+
+      stdout, stderr, status = Open3.capture3(Gem.ruby, '-I', lib_dir, smoke_test)
+
+      expect(status).to be_success,
+                        "library must work in a clean consumer process.\nstdout: #{stdout}\nstderr: #{stderr}"
+    end
   end
 
   describe 'deprecated methods' do


### PR DESCRIPTION
**Description**
`base64` was demoted as a default gem in Ruby 3.4. Subsequently, it's been dropped as a dependency in `faraday`. Therefore, our library no longer has a way of finding the `base64` dependency it needs for several methods in the `hmac_validator` and the `spec_helper`. 

Unit tests still pass because they are run in development mode + we have `activesupport` as a development dependency, which requires `base64`. However, these development dependencies aren't imported by consumers of the library, so they'll get an error if trying to use the `HmacValidator` methods.

Can be reproduced locally by using the `HmacValidator` as a consumer (via `require`):
```
$ bundle exec ruby -I lib -e 'require "adyen-ruby-api-library";
         Adyen::Utils::HmacValidator.new.calculate_webhook_hmac({"pspReference"=>"x"}, "44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056")'
$ ... uninitialized constant Adyen::Utils::HmacValidator::Base64 (NameError)
```

Opted to drop the `base64`  dependency since the encoding methods we use there are just wrappers for the `.pack()` method anyway. Additionally, added missing `require 'openssl'` for code hygiene.

**Tested scenarios**
- Added a consumer-side regression test which spins up a subprocess that runs a clean Ruby script (no other dependencies other than the library) and performs a simple operation with the HMAC validator to check if the library is self-sufficient (i.e. does not require other dependencies)
